### PR TITLE
pi-model-tools 0.6.0: hook-based tool interception + generic sandbox compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ into the Pi coding agent, each in its own npm package under `@bacnh85/`.
 | **pi-agy** | 0.3.1 | Google Antigravity CLI bridge for delegated implementation, scaffolding, refactors, and test generation. |
 | **pi-fff** | 0.7.9 | FFF-powered fuzzy file and content search for Pi. |
 | **pi-kicad** | 0.1.3 | KiCad CAD-design extension — drive schematic capture and PCB layout via the Konnect binary over a local HTTP daemon (no MCP SDK). |
-| **pi-model-tools** | 0.5.5 | Unified tool-wrapping, argument repair, reasoning management, DeepSeek V4 guidance + Super Power Mode, defensive leak-cleaning, edit mismatch repair, and a Codex-style apply_patch diff tool. |
+| **pi-model-tools** | 0.6.0 | Hook-based tool interception, argument repair, reasoning management, DeepSeek V4 guidance + Super Power Mode, defensive leak-cleaning, edit mismatch repair, and a Codex-style apply_patch diff tool. |
 | **pi-munin** | 0.5.2 | Munin long-term memory as eight native Pi tools for search, retrieval, storage, listing, deletion, capabilities, and confirmed cross-project sharing. |
 | **pi-evolve** | 0.3.1 | Trajectory-based self-learning loop — captures tool-call trajectories, reflects to extract learnings, persists to Munin or local JSONL, injects recent learnings into future sessions. |
 | **pi-a2a** | 0.1.1 | A2A Protocol v1.0 bidirectional — Pi distributes tasks to remote agents (Hermes, ADK, LangChain, any A2A peer) and exposes itself as an A2A-callable agent. |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Each package lives in its own directory and can be installed independently. This
 | [`@bacnh85/pi-fff`](./pi-fff) | 0.7.9 | FFF-powered fuzzy file and content search for Pi. |
 | [`@bacnh85/pi-init`](./pi-init) | 0.1.0 | Guided AGENTS.md generation — `/init` scans the repo and generates/updates AGENTS.md with build/test/lint commands, architecture, and conventions. |
 | [`@bacnh85/pi-kicad`](./pi-kicad) | 0.1.3 | KiCad CAD-design extension — drive schematic capture and PCB layout via the Konnect binary over a local HTTP daemon. |
-| [`@bacnh85/pi-model-tools`](./pi-model-tools) | 0.5.5 | Unified tool-wrapping, argument repair, reasoning management, DeepSeek V4 guidance + Super Power Mode, defensive leak-cleaning, edit mismatch repair, and a Codex-style `apply_patch` diff tool. |
+| [`@bacnh85/pi-model-tools`](./pi-model-tools) | 0.6.0 | Hook-based tool interception, argument repair, reasoning management, DeepSeek V4 guidance + Super Power Mode, defensive leak-cleaning, edit mismatch repair, and a Codex-style `apply_patch` diff tool. |
 | [`@bacnh85/pi-munin`](./pi-munin) | 0.5.2 | Munin long-term memory as eight native Pi tools for search, retrieval, storage, listing, deletion, capabilities, and cross-project sharing. |
 | [`@bacnh85/pi-notebooklm`](./pi-notebooklm) | 0.1.8 | Google NotebookLM — notebooks, sources, chat, research, and Studio artifacts via CLI bridge. |
 | [`@bacnh85/pi-notify`](./pi-notify) | 0.1.0 | Desktop notifications and sounds — fires on task completion, errors, and questions; cross-platform (macOS/Linux/Windows + terminal OSC). |

--- a/pi-model-tools/CHANGELOG.md
+++ b/pi-model-tools/CHANGELOG.md
@@ -1,5 +1,64 @@
 # Changelog
 
+## 0.6.0 (2026-08-14)
+
+### Architecture — hook-based tool interception (sandbox-safe)
+
+- **The built-in tools are no longer re-registered.** The extension dropped the
+  `wrapToolDefinition` layer that registered read/write/edit/grep/find/ls/bash
+  via `pi.registerTool()`. The host resolves duplicate tool names by
+  **first-registration-per-name** with no conflict error (`_refreshToolRegistry`),
+  so the old wrapper silently clobbered any other extension that owned those
+  tools (e.g. a sandbox's VM-wrapped tools) — and which extension won depended on
+  load order. All interception now runs through the SDK's documented `tool_call` /
+  `tool_result` hooks ("mutate `event.input` in place to patch tool arguments
+  before execution"), which compose with whichever extension registered the tool
+  and are load-order independent. The extension's only registration is the
+  `apply_patch` tool and the `/model-tools-status` command.
+- **Edit repair moved from the execute wrapper into the hooks.** Contamination
+  stripping + indentation-drift pre-flight now run in the `tool_call` hook
+  (before the sandboxed edit executes, rewriting `event.input.edits` in place);
+  the nearest-region error enrichment runs in the new `tool_result` hook. No
+  more catch-and-rethrow — the tool executes once. This also makes edit repair
+  work for extensions that own the edit tool.
+- **Read defaults / `__mtReadNote` dropped.** The base `read` tool already
+  applies `offset=1`/`limit=2000` semantics and emits its own continuation
+  notices, so the wrapper's additive defaults and appended note were redundant.
+- **Generic sandbox detection + apply_patch gate.** A session is sandboxed when
+  `PI_TOOLS_ARE_SANDBOXED` is declared (`1`/`true`/`yes`/`on`; `0`/`false`/`no`/
+  `off` overrides) or auto-detected: any of `read`/`write`/`edit`/`bash` is owned
+  by an extension (`sourceInfo.source` != `builtin`), captured at `session_start`.
+  Our `apply_patch` (raw `node:fs` writes) is hard-blocked at runtime in the
+  `tool_call` hook when sandboxed — detection is per-session, not at load, so
+  the gate is load-order independent. A sandbox-owned `apply_patch` is allowed
+  and still steered. Registration can be skipped entirely with
+  `PI_MODEL_TOOLS_APPLY_PATCH=0`. apply_patch steering is suppressed while ours
+  is blocked; error hints steer sandboxed `ENOENT` (permission denials are
+  masked as not-found) to `request_access` when that tool is registered, else to
+  generic access-granting recovery instead of "find first". Sandboxing
+  extensions set `PI_TOOLS_ARE_SANDBOXED` in their module top-level (extension
+  modules load before `session_start`, so it is visible to all handlers
+  regardless of load order).
+
+### Fixes
+
+- **Dangerous-command guard and read-on-guessed-path blocking now run for all
+  families** (previously gated behind the DeepSeek/GLM early return). This
+  matches the documented behavior — the safety guard and correctness block are
+  family-independent and now also fire on undetected models.
+- **`categorizeToolError` accepts a `sandboxed` option** (see above) for the
+  ENOENT-vs-denied distinction.
+
+### Internal
+
+- New `index.test.ts` harness drives the extension through a stub
+  `ExtensionAPI`: asserts the 7 built-in tools are NOT re-registered, apply_patch
+  env gating, per-session sandbox detection + runtime block, load-order
+  independence, in-place `event.input` mutation (pre-flight + argument repair),
+  the dangerous-command guard, and tool_result enrichment.
+- `computePreflightEdits` / `editErrorEnrichment` added to `lib/edit-repair.ts`
+  (pure, unit-tested); `applyPatchEnabled` added to `lib/model-detection.ts`.
+
 ## 0.5.5 (2026-08-05)
 
 ### Improvements

--- a/pi-model-tools/README.md
+++ b/pi-model-tools/README.md
@@ -1,13 +1,17 @@
 # @bacnh85/pi-model-tools
 
-**Unified model-family support for Pi** — tool-wrapping, argument repair,
+**Unified model-family support for Pi** — tool interception, argument repair,
 reasoning management, defensive leak-cleaning, DeepSeek V4 selection guidance,
 and Super Power Mode, all in one extension. Currently supports **DeepSeek V4**
 and **GLM** (GLM-4.5 through GLM-5.2) from any provider.
 
-This is the **single source of tool-wrapping** for these families. It registers
-the 7 built-in Pi tools (read, write, edit, grep, find, ls, bash) exactly once
-and routes behavior by detected model family.
+This is the **single source of tool handling** for these families. It does NOT
+re-register the built-in tools (read, write, edit, grep, find, ls, bash) —
+`pi.registerTool` resolves name collisions by last-wins, so re-registering
+would silently clobber other extensions that own those tools. Instead it
+intercepts through the SDK's `tool_call`/`tool_result` hooks (in-place
+`event.input` mutation), which compose with whichever extension registered the
+tool, and routes behavior by detected model family.
 
 > **Merged package (v0.2.0).** This package now absorbs the former
 > `pi-deepseek-tools` and `pi-glm` extensions. Those packages are deprecated;
@@ -18,11 +22,16 @@ and routes behavior by detected model family.
 ## Why one package
 
 Pi's `ExtensionAPI` cannot conditionally register tools — `registerTool()`
-runs at load time, conflicts are detected post-load (uncatchable), and there is
-no `unregisterTool()`. The previous three-package split (pi-model-tools for
-tool-wrapping + pi-deepseek-tools + pi-glm for hooks) duplicated substantial
-code across packages. Merging into one extension eliminates the duplication and
-the "load three packages" ceremony while keeping every behavior.
+runs at load time, name collisions resolve by last-wins (no conflict error), and
+there is no `unregisterTool()`. Re-registering the built-in tools from an
+extension therefore silently clobbers any other extension that also owns them.
+Intercepting via the `tool_call`/`tool_result` hooks (documented: "mutate
+`event.input` in place to patch tool arguments before execution") achieves the
+same behavior without touching the registry, and is load-order independent.
+The previous three-package split (pi-model-tools for tool-wrapping +
+pi-deepseek-tools + pi-glm for hooks) duplicated substantial code across
+packages. Merging into one extension eliminates the duplication and the "load
+three packages" ceremony while keeping every behavior.
 
 ## Model family detection
 
@@ -54,8 +63,8 @@ a family is detected; everything degrades gracefully to a no-op otherwise.
 | **Read-on-guessed-path blocking** | Blocks `read` on a non-existent code-file path, suggests `find` first |
 | **Prompt-aware first-tool hints** | Forces the correct first tool: `bash`-first for RUN/BUILD/EXECUTE tasks, `bash` git-clone-first for analyze-a-repo-URL tasks, and `find`-first for bare-filename reads. Targeted (only fires on matching intent) and applied to all detected families. Injected into the current user message, not the system prompt, to keep the prefix-cache head byte-stable for both DeepSeek (exact-prefix cache) and GLM (Z.ai automatic content-similarity cache) (measured on DeepSeek: 99% hit retained vs 16% when hints lived in the system prompt). |
 | **Error categorization** | Classifies tool errors and injects recovery hints on the next turn. Also detects provider 400s caused by accumulated `reasoning_content` (long-session reasoning-accumulation) and injects an actionable hint — `PI_MODEL_TOOLS_STRIP_REASONING=1` — so the rare trigger is self-documenting. |
-| **Edit mismatch repair** | Strips `read`-tool truncation notices (`[Showing lines … Use offset=N to continue.]`, etc.) that models copy into `edit` oldText — the documented root cause of "Could not find the exact text" failures. On a match failure, retries once with whitespace-tolerant matching (copying the file's real indentation); on unresolvable matches, enriches the error with the nearest numbered region. Always on. |
-| **`apply_patch` tool** | A Codex-style V4D diff/patch tool: emit only `@@` context + `-`/`+` change lines instead of large verbatim oldText blocks. Robust for multi-line/multi-file edits across all models. DeepSeek/GLM get steering to prefer it for non-trivial edits. |
+| **Edit mismatch repair** | Strips `read`-tool truncation notices (`[Showing lines … Use offset=N to continue.]`, etc.) that models copy into `edit` oldText — the documented root cause of "Could not find the exact text" failures. Before the edit executes, oldText is pre-flighted against a whitespace-tolerant match and rewritten to the file's real indentation when the match is unique; unresolvable mismatches get their error enriched with the nearest numbered region. Always on. |
+| **`apply_patch` tool** | A Codex-style V4D diff/patch tool: emit only `@@` context + `-`/`+` change lines instead of large verbatim oldText blocks. Robust for multi-line/multi-file edits across all models. DeepSeek/GLM get steering to prefer it for non-trivial edits. Writes directly to the host filesystem, so it is hard-blocked at runtime in sandboxed sessions; registration can be skipped entirely via `PI_MODEL_TOOLS_APPLY_PATCH=0`. |
 
 ### Prompt caching
 
@@ -97,6 +106,44 @@ family is active.
 | **Strict Serena mode** | Optionally hard-blocks simple `bash` substitutes (`ls`, `grep`, `cat`, `find`, `head`, `tail`) for dedicated tools |
 | **Super Power Mode** | Prepends an unrestricted capability prompt each DeepSeek session (see below) |
 
+## Sandbox compatibility
+
+`pi-model-tools` interoperates with sandboxing extensions — such as
+**pi-tg-gondolin** (a VM sandbox that re-registers the built-in tools inside a
+virtual machine) — by intercepting via
+the `tool_call` hook instead of re-registering anything. The host resolves a
+tool name registered by multiple extensions by **first-registration-per-name**,
+so both extensions coexist regardless of load order.
+
+A session is treated as **sandboxed** when either:
+
+- `PI_TOOLS_ARE_SANDBOXED` is set to `1`/`true`/`yes`/`on` — the shared
+  convention flag. A sandboxing extension sets it in its module top-level (all
+  extension modules load before `session_start`, so it is visible to every
+  extension regardless of load order); launchers can also set it. Set it to
+  `0`/`false`/`no`/`off` to override auto-detection.
+- otherwise, auto-detected: any of the host file tools (`read`/`write`/`edit`/`bash`)
+  is owned by an extension rather than the host (its `sourceInfo` is not
+  `builtin`).
+
+When sandboxed:
+
+- **`apply_patch` is hard-blocked at runtime** only when the *live* `apply_patch`
+  is ours — the raw `node:fs` version that would bypass the sandbox VM. If the
+  sandbox owns `apply_patch` (VM-routed), it is allowed and still suggested.
+  The block fires in the `tool_call` hook before any owner executes it, so it is
+  load-order independent. Set `PI_MODEL_TOOLS_APPLY_PATCH=0` to skip registration
+  entirely.
+- **Edit repair composes with the VM-wrapped edit.** Pre-flight rewriting and
+  `tool_result` error enrichment run in the hooks, so they work whether the
+  host's or the sandbox's `edit` executes.
+- **Permission denials read correctly.** Sandboxed paths denied to the agent
+  surface as `ENOENT`; error hints steer to `request_access` when that tool is
+  present, otherwise to generic access-granting recovery, instead of the usual
+  "find first".
+- **`apply_patch` steering is suppressed** when ours is blocked, so the model
+  isn't nudged into a call that would be rejected.
+
 ## Installation
 
 ```bash
@@ -135,26 +182,32 @@ Rules:
   Unicode-normalize), so minor whitespace/Unicode differences still apply.
 
 DeepSeek and GLM are steered to prefer `apply_patch` for multi-line/multi-hunk
-edits; Claude/OpenAI keep using `edit` (they're already reliable with it).
+edits; Claude/OpenAI keep using `edit` (they're already reliable with it). In
+sandboxed sessions the hint is suppressed while our raw-fs `apply_patch` is
+blocked (see [Sandbox compatibility](#sandbox-compatibility)).
 
 ## Commands
 
 | Command | Description |
 |---------|-------------|
-| `/model-tools-status` | Shows detected family, repair counts, error history, prompt-cache stats (input/cached/written tokens + hit rate), and DeepSeek Super Power Mode + turn count |
+| `/model-tools-status` | Shows detected family, sandbox state (`yes (declared)` / `yes (auto-detected)` / `no`), repair counts, error history, prompt-cache stats (input/cached/written tokens + hit rate), and DeepSeek Super Power Mode + turn count |
 
 ## Configuration
 
-All toggles live under the `PI_MODEL_TOOLS_*` namespace.
+All toggles live under the `PI_MODEL_TOOLS_*` namespace, with one exception:
+`PI_TOOLS_ARE_SANDBOXED` is the cross-extension sandbox convention (see
+[Sandbox compatibility](#sandbox-compatibility)).
 
 ### Shared
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
+| `PI_TOOLS_ARE_SANDBOXED` | unset | Declare the session sandboxed (`1`/`true`/`yes`/`on`) or override auto-detection (`0`/`false`/`no`/`off`). Shared with sandboxing extensions. |
 | `PI_MODEL_TOOLS_REPAIR_ENABLED` | 1 | Tool argument repair (`0`/`off`/`false` to disable) |
 | `PI_MODEL_TOOLS_STRIP_REASONING` | 0 | Strip accumulated reasoning from prior turns |
 | `PI_MODEL_TOOLS_REASONING_MAX_CHARS` | unlimited | Truncate long reasoning fields to N characters |
 | `PI_MODEL_TOOLS_BLOCK_DANGEROUS_COMMANDS` | 1 | Safety guard (on by default) |
+| `PI_MODEL_TOOLS_APPLY_PATCH` | 1 | Register the `apply_patch` tool (`0`/`off`/`false` to skip registration) |
 | `PI_MODEL_TOOLS_AUTO_BLOCK_AFTER_REMINDERS` | 0 | Auto-block tool-selection misses after N reminders |
 | `PI_MODEL_TOOLS_MAX_ERROR_HISTORY` | 100 | Maximum tracked tool errors |
 | `PI_MODEL_TOOLS_DEBUG` | 0 | stderr diagnostic logging |
@@ -176,11 +229,12 @@ All toggles live under the `PI_MODEL_TOOLS_*` namespace.
 
 ## Super Power Mode
 
-Enabled by default for DeepSeek V4 sessions. It prepends an unrestricted
-capability prompt at the top of the system prompt (before the selection
-guidance and the base prompt), removes content filters, and engages maximum
-reasoning effort. A light reinforcement is appended every 10 turns.
-
+Off by default for DeepSeek V4 sessions (the global AGENTS.md already enforces
+the same behavior, and the persona prompt adds permanent prefix-cache cost).
+When enabled, it prepends an unrestricted capability prompt at the top of the
+system prompt (before the selection guidance and the base prompt), removes
+content filters, and engages maximum reasoning effort. A light reinforcement
+is appended every 10 turns.
 ```bash
 # Enable (off by default)
 export PI_MODEL_TOOLS_SUPERPOWER_MODE=1
@@ -211,6 +265,8 @@ npm pack --dry-run
 | `/model-tools-status` not found | Extension not loaded | Check settings and run `/reload` |
 | Super Power prompt not injecting | `PI_MODEL_TOOLS_SUPERPOWER_MODE` not `1`/`on`/`true`, or model is not DeepSeek V4 | Set `=1` and verify the model id contains `deepseek` and `v4` |
 | Custom Super Power prompt not loading | `PI_MODEL_TOOLS_CUSTOM_SUPERPOWER_PROMPT` unset | Set the env var to your prompt text |
+| `apply_patch` blocked in sandboxed sessions | A sandboxing extension is active (auto-detected or `PI_TOOLS_ARE_SANDBOXED=1`) | Intentional: our `apply_patch` writes raw `node:fs` and would bypass the sandbox. Use `edit`; set `PI_MODEL_TOOLS_APPLY_PATCH=0` to skip registration, or `PI_TOOLS_ARE_SANDBOXED=0` to override detection |
+| `apply_patch` missing from the tool list | `PI_MODEL_TOOLS_APPLY_PATCH=0` | Unset the env var to register it |
 | Old config ignored | Still using `PI_DEEPSEEK_TOOLS_*` / `PI_GLM_*` names | Rename to `PI_MODEL_TOOLS_*` (see tables above) |
 
 ## Changelog

--- a/pi-model-tools/extensions/index.ts
+++ b/pi-model-tools/extensions/index.ts
@@ -2,16 +2,8 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { dirname, resolve as resolvePath } from "node:path";
-import {
-  createBashToolDefinition,
-  createEditToolDefinition,
-  createFindToolDefinition,
-  createGrepToolDefinition,
-  createLsToolDefinition,
-  createReadToolDefinition,
-  createWriteToolDefinition,
-  defineTool,
-} from "@earendil-works/pi-coding-agent";
+import { fileURLToPath } from "node:url";
+import { defineTool } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import {
   isRecord,
@@ -22,13 +14,14 @@ import {
   maxErrorHistory,
   autoBlockAfterReminders,
   blockDangerousEnabled,
+  applyPatchEnabled,
+  isSandboxed,
 } from "./lib/model-detection.ts";
-import { repairToolArguments, type RepairKind } from "./lib/tool-input-repair.ts";
+import { repairToolArguments } from "./lib/tool-input-repair.ts";
 import {
   stripReadContamination,
-  computeRetryEdit,
-  nearestBlock,
-  parseFailedEditIndex,
+  computePreflightEdits,
+  editErrorEnrichment,
   isEditMismatchError,
   stripBom as stripBomStr,
   normalizeToLF,
@@ -60,19 +53,23 @@ import {
   superPowerPromptContent,
 } from "./lib/guidance.ts";
 
-function addReadDefaults(args: unknown): unknown {
-  if (!isRecord(args)) return args;
-  if ((args.offset !== undefined) === (args.limit !== undefined)) return args;
-  const defaults = args.limit !== undefined ? { offset: 1 } : { limit: 2000 };
-  const note = args.limit !== undefined
-    ? "Note: offset was not provided; defaulted to 1."
-    : "Note: limit was not provided; defaulted to 2000 lines.";
-  return { ...args, ...defaults, __mtReadNote: note };
-}
+// The built-in tools whose arguments pi-model-tools repairs/intercepts. This is
+// the exact scope of the former tool-wrapping (the same 7 names); other tools
+// keep their own arguments untouched.
+const SCHEMA_TOOL_NAMES = new Set(["read", "write", "edit", "grep", "find", "ls", "bash"]);
 
-function appendReadNote(result: any, note: unknown) {
-  if (typeof note !== "string" || !note) return result;
-  return { ...result, content: [...(Array.isArray(result?.content) ? result.content : []), { type: "text", text: note }] };
+// Our own extension path, used to tell whether the live apply_patch is our
+// registration or another extension's (see liveApplyPatchIsOurs).
+const OUR_EXTENSION_PATH = fileURLToPath(import.meta.url);
+
+// Whether a tool's sourceInfo identifies pi-model-tools' own registration.
+// ponytail: substring identity match — robust across npm vs local-path installs
+// without importing package.json.
+function isOwnToolSource(sourceInfo?: { source?: string; path?: string } | null): boolean {
+  if (!sourceInfo) return false;
+  const source = sourceInfo.source ?? "";
+  const path = sourceInfo.path ?? "";
+  return source.includes("pi-model-tools") || path.includes("pi-model-tools") || path === OUR_EXTENSION_PATH;
 }
 
 // Strip read-tool contamination notices from an edit's oldText fields. Mutates
@@ -97,7 +94,8 @@ function decontaminateEditArgs(args: any): boolean {
 }
 
 // Locate the file, read it, and report its (BOM-stripped, LF-normalized)
-// content for trim-tolerant retry. Returns null on any I/O problem.
+// content for trim-tolerant pre-flight and error enrichment. Returns null on
+// any I/O problem.
 async function readFileForRetry(filePath: string, cwd: string): Promise<string | null> {
   const abs = resolvePath(cwd, filePath);
   try {
@@ -108,80 +106,7 @@ async function readFileForRetry(filePath: string, cwd: string): Promise<string |
   }
 }
 
-function wrapToolDefinition(base: any, factory: (cwd: string) => any, shouldRepair: () => boolean, onRepair: (toolName: string, repairs: readonly RepairKind[]) => void): any {
-  return {
-    ...base,
-    prepareArguments(args: unknown) {
-      let prepared = base.prepareArguments ? base.prepareArguments(args as never) : args;
-      if (shouldRepair()) {
-        const repaired = repairToolArguments(base.name, base.parameters, prepared);
-        if (repaired.repaired) { onRepair(base.name, repaired.repairs); prepared = repaired.args; }
-      }
-      // Strip read-tool contamination from edit oldText (always on — it's a
-      // safe, deterministic fix for the documented mismatch root cause).
-      if (base.name === "edit" && isRecord(prepared)) {
-        if (decontaminateEditArgs(prepared)) {
-          onRepair(base.name, ["read-notice-stripped"]);
-        }
-      }
-      return base.name === "read" ? addReadDefaults(prepared) : prepared;
-    },
-    async execute(toolCallId: string, params: any, signal: AbortSignal | undefined, onUpdate: any, ctx: any) {
-      const cwd = ctx?.cwd || process.cwd();
-      const freshDef = factory(cwd);
-      const readNote = base.name === "read" && isRecord(params) ? params.__mtReadNote : undefined;
-      if (isRecord(params)) delete params.__mtReadNote;
-
-      if (base.name !== "edit") {
-        const result = await freshDef.execute(toolCallId, params, signal, onUpdate, ctx);
-        return base.name === "read" ? appendReadNote(result, readNote) : result;
-      }
-
-      // edit: try once; on a match-failure, retry once with trim-tolerant
-      // matching (copying actual file bytes) before giving up with a richer
-      // error that shows the nearest region.
-      try {
-        const result = await freshDef.execute(toolCallId, params, signal, onUpdate, ctx);
-        return result;
-      } catch (err: any) {
-        const message: string = err?.message ? String(err.message) : "";
-        if (!isEditMismatchError(message)) throw err;
-
-        const filePath = typeof params?.path === "string" ? params.path : "";
-        if (!filePath) throw err;
-        const fileContent = await readFileForRetry(filePath, cwd);
-        if (fileContent === null) throw err;
-
-        const edits: { oldText: string; newText: string }[] = Array.isArray(params?.edits) && params.edits.length > 0
-          ? params.edits
-          : (typeof params?.oldText === "string" ? [{ oldText: params.oldText, newText: params.newText }] : []);
-        if (edits.length === 0) throw err;
-
-        const retry = computeRetryEdit(fileContent, edits, parseFailedEditIndex(message));
-        if (retry) {
-          // Rebuild oldText from the file's real bytes (real indentation) so the
-          // core exact matcher succeeds; keep the model's newText as-is.
-          const fixedParams = { ...params };
-          if (Array.isArray(fixedParams.edits)) fixedParams.edits = retry.fixedEdits;
-          else fixedParams.oldText = retry.fixedEdits[0].oldText;
-          onRepair(base.name, ["trim-match-retry"]);
-          return await freshDef.execute(toolCallId, fixedParams, signal, onUpdate, ctx);
-        }
-
-        // Unresolvable: enrich the error with the nearest region so the model
-        // can copy verbatim on the next turn. categorizeToolError checks
-        // edit_mismatch before rate_limit/timeout for the edit tool, so a snippet
-        // containing 'timeout'/'429' cannot misclassify this.
-        const failing = edits[Math.min(parseFailedEditIndex(message), edits.length - 1)];
-        const nearest = failing ? nearestBlock(fileContent, stripReadContamination(failing.oldText).text) : "";
-        throw new Error(nearest ? `${message}\n\n${nearest}` : message);
-      }
-    },
-  };
-}
-
 export default function (pi: ExtensionAPI) {
-  let repairThisTurn = false;
   let hasErrorThisTurn = false;
   let lastErrorInfo: ErrorInfo | null = null;
   let remindedThisTurn = false;
@@ -198,6 +123,38 @@ export default function (pi: ExtensionAPI) {
   const reminderCounts = new Map<string, number>();
   const errorHistory = new Map<string, { count: number; lastCategory: ErrorCategory }>();
 
+  // Sandbox detection is generic and load-order independent. A sandboxing
+  // extension re-registers the host file tools (read/write/edit/bash) and wins
+  // the host's first-registration-per-name resolution, so those tools then carry
+  // a non-"builtin" sourceInfo in getAllTools(). `PI_TOOLS_ARE_SANDBOXED` is the
+  // shared declared-override convention (set by the sandbox extension at module
+  // top-level; all modules load before session_start, so it is visible here
+  // regardless of load order). The tool snapshot is taken per session — not at
+  // load — because the registry is only fully built after every extension has
+  // loaded. `sandboxActive()` re-reads the env at call time, so a lazily-set
+  // variable is still caught by the runtime block/hint.
+  let toolSnapshot: Array<{ name: string; sourceInfo?: { source?: string; path?: string } | null }> = [];
+  function sandboxActive(): boolean {
+    return isSandboxed(process.env, toolSnapshot);
+  }
+  // The live apply_patch is ours (rather than a sandbox extension's) when the
+  // tool in getAllTools() carries our package/path identity.
+  function liveApplyPatchIsOurs(): boolean {
+    const tool = toolSnapshot.find((t) => t.name === "apply_patch");
+    return tool ? isOwnToolSource(tool.sourceInfo) : false;
+  }
+  // Our raw node:fs apply_patch must never run while the host tools are
+  // sandboxed — if another extension owns the live apply_patch it is VM-routed
+  // and safe, so only our registration is blocked.
+  function applyPatchBlocked(): boolean {
+    return sandboxActive() && liveApplyPatchIsOurs();
+  }
+  function hasRequestAccessTool(): boolean {
+    return toolSnapshot.some((t) => t.name === "request_access");
+  }
+  // Snapshot of the built-in tools' parameter schemas, used by argument repair.
+  let schemaByName = new Map<string, unknown>();
+
   function recordError(toolName: string, category: ErrorCategory) {
     errorHistory.set(toolName, { count: (errorHistory.get(toolName)?.count ?? 0) + 1, lastCategory: category });
     while (errorHistory.size > maxErrorHistory()) errorHistory.delete(errorHistory.keys().next().value!);
@@ -208,64 +165,77 @@ export default function (pi: ExtensionAPI) {
     return detectFamily(model) ?? detectFamily(sessionModel);
   }
 
-  // ── Register wrapped built-in tools ONCE (the single source of tool-wrapping) ──
-  const toolFactories: Record<string, (cwd: string) => any> = {
-    read: createReadToolDefinition, write: createWriteToolDefinition, edit: createEditToolDefinition,
-    grep: createGrepToolDefinition, find: createFindToolDefinition, ls: createLsToolDefinition, bash: createBashToolDefinition,
-  };
-  for (const f of Object.values(toolFactories)) {
-    const template = f(process.cwd());
-    pi.registerTool(wrapToolDefinition(template, f, () => repairThisTurn, (toolName) => {
-      repairCounts.set(toolName, (repairCounts.get(toolName) ?? 0) + 1);
-      debugLog("repair:", toolName, repairCounts.get(toolName));
-    }));
+  function onRepair(toolName: string) {
+    repairCounts.set(toolName, (repairCounts.get(toolName) ?? 0) + 1);
+    debugLog("repair:", toolName, repairCounts.get(toolName));
+  }
+
+  // Apply repaired args back into event.input IN PLACE — the documented
+  // tool_call contract ("mutate event.input in place to patch tool arguments
+  // before execution"); the agent executes the same object reference. Returns
+  // false when the repaired args cannot be represented on the input object
+  // (e.g. a whole-args JSON string that repaired into an object).
+  function applyRepairInPlace(input: unknown, args: unknown): boolean {
+    if (!isRecord(input) || !isRecord(args)) return false;
+    const target = input as Record<string, unknown>;
+    const next = args as Record<string, unknown>;
+    for (const key of Object.keys(target)) if (!(key in next)) delete target[key];
+    for (const [key, value] of Object.entries(next)) target[key] = value;
+    return true;
   }
 
   // ── apply_patch: Codex-style diff/patch tool (robust for weak models) ──
-  pi.registerTool(defineTool({
-    name: "apply_patch",
-    label: "apply_patch",
-    description: [
-      "Apply a Codex-style V4D patch to edit one or more files. Emit only changed lines plus a little surrounding context (a small diff), which is easier to get right than reproducing a large verbatim block. Supported sections: `*** Add File: <path>` (only `+` lines), `*** Delete File: <path>` (no payload), `*** Update File: <path>` or `*** Update File: <old> → <new>` (rename). Inside an Update section, each hunk is preceded by a `@@` anchor line whose text is an unchanged context line, then `-` removed lines and `+` added lines. Leading-space context lines (` `) are also allowed. If the @@ anchor text is restated as the immediately-following context or removed line, the duplicate is auto-collapsed. Context+removed must match UNIQUELY in the file. Wrap the whole patch in `*** Begin Patch` ... `*** End Patch`.",
-      "",
-      "Example:",
-      "*** Begin Patch", "*** Update File: src/foo.ts", "@@ export function foo()", "-  return 1", "+  return 2", "*** End Patch",
-    ].join("\n"),
-    promptSnippet: "Apply a diff/patch to edit one or more files (Codex V4D format)",
-    promptGuidelines: [
-      "Use apply_patch for multi-line or multi-file edits: emit a small diff (context + -/+ lines) instead of reproducing large verbatim oldText blocks.",
-      "Each Update hunk needs a unique anchor: include enough unchanged context lines so the context+removed block matches exactly once in the file.",
-      "If the @@ anchor repeats on the very next line (as space-context or -removed), the duplicate is auto-collapsed.",
-      "For a single tiny one-line replacement, edit is fine; for anything larger or spanning multiple files, prefer apply_patch.",
-    ],
-    parameters: Type.Object({ patch: Type.String({ description: "The V4D patch text, wrapped in *** Begin Patch ... *** End Patch." }) }),
-    renderShell: "self",
-    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      const cwd = ctx?.cwd || process.cwd();
-      let parsed;
-      try {
-        parsed = parsePatch(params.patch);
-      } catch (err) {
-        const msg = err instanceof PatchParseError ? err.message : String(err);
-        return { content: [{ type: "text", text: `Invalid patch: ${msg}` }], isError: true, details: undefined };
-      }
-      try {
-        const res = await applyPatchToFiles(parsed, cwd);
-        const summary = res.files.map((f) => {
-          if (f.kind === "add") return `Added ${f.path}`;
-          if (f.kind === "delete") return `Deleted ${f.path}`;
-          return `Updated ${f.path}`;
-        }).join("\n");
-        const exactness = res.exact ? "" : "\nNote: some hunks matched via fuzzy (whitespace/Unicode) normalization.";
-        return {
-          content: [{ type: "text", text: `${summary}${exactness}` }],
-          details: { diff: res.diff, files: res.files.map((f) => f.path) },
-        };
-      } catch (err) {
-        return { content: [{ type: "text", text: err instanceof Error ? err.message : String(err) }], isError: true, details: undefined };
-      }
-    },
-  }));
+  // Registration is skippable via PI_MODEL_TOOLS_APPLY_PATCH=0. If another
+  // extension already owns apply_patch, the host's first-registration-per-name
+  // resolution drops ours silently. When ours is the live tool inside a
+  // sandboxed session (it writes raw node:fs anywhere, bypassing the sandbox)
+  // it is hard-blocked at runtime — see the tool_call sandbox gate.
+  if (applyPatchEnabled()) {
+    pi.registerTool(defineTool({
+      name: "apply_patch",
+      label: "apply_patch",
+      description: [
+        "Apply a Codex-style V4D patch to edit one or more files. Emit only changed lines plus a little surrounding context (a small diff), which is easier to get right than reproducing a large verbatim block. Supported sections: `*** Add File: <path>` (only `+` lines), `*** Delete File: <path>` (no payload), `*** Update File: <path>` or `*** Update File: <old> → <new>` (rename). Inside an Update section, each hunk is preceded by a `@@` anchor line whose text is an unchanged context line, then `-` removed lines and `+` added lines. Leading-space context lines (` `) are also allowed. If the @@ anchor text is restated as the immediately-following context or removed line, the duplicate is auto-collapsed. Context+removed must match UNIQUELY in the file. Wrap the whole patch in `*** Begin Patch` ... `*** End Patch`.",
+        "",
+        "Example:",
+        "*** Begin Patch", "*** Update File: src/foo.ts", "@@ export function foo()", "-  return 1", "+  return 2", "*** End Patch",
+      ].join("\n"),
+      promptSnippet: "Apply a diff/patch to edit one or more files (Codex V4D format)",
+      promptGuidelines: [
+        "Use apply_patch for multi-line or multi-file edits: emit a small diff (context + -/+ lines) instead of reproducing large verbatim oldText blocks.",
+        "Each Update hunk needs a unique anchor: include enough unchanged context lines so the context+removed block matches exactly once in the file.",
+        "If the @@ anchor repeats on the very next line (as space-context or -removed), the duplicate is auto-collapsed.",
+        "For a single tiny one-line replacement, edit is fine; for anything larger or spanning multiple files, prefer apply_patch.",
+      ],
+      parameters: Type.Object({ patch: Type.String({ description: "The V4D patch text, wrapped in *** Begin Patch ... *** End Patch." }) }),
+      renderShell: "self",
+      async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+        const cwd = ctx?.cwd || process.cwd();
+        let parsed;
+        try {
+          parsed = parsePatch(params.patch);
+        } catch (err) {
+          const msg = err instanceof PatchParseError ? err.message : String(err);
+          return { content: [{ type: "text", text: `Invalid patch: ${msg}` }], isError: true, details: undefined };
+        }
+        try {
+          const res = await applyPatchToFiles(parsed, cwd);
+          const summary = res.files.map((f) => {
+            if (f.kind === "add") return `Added ${f.path}`;
+            if (f.kind === "delete") return `Deleted ${f.path}`;
+            return `Updated ${f.path}`;
+          }).join("\n");
+          const exactness = res.exact ? "" : "\nNote: some hunks matched via fuzzy (whitespace/Unicode) normalization.";
+          return {
+            content: [{ type: "text", text: `${summary}${exactness}` }],
+            details: { diff: res.diff, files: res.files.map((f) => f.path) },
+          };
+        } catch (err) {
+          return { content: [{ type: "text", text: err instanceof Error ? err.message : String(err) }], isError: true, details: undefined };
+        }
+      },
+    }));
+  }
 
   // ── /model-tools-status ──
   pi.registerCommand("model-tools-status", {
@@ -288,6 +258,10 @@ export default function (pi: ExtensionAPI) {
         `  Super Power Mode (DeepSeek): ${superPowerModeEnabled() ? "on" : "off"}`,
         `  Super Power turns: ${turnCounter}`,
         `  Debug: ${process.env.PI_MODEL_TOOLS_DEBUG ? "on" : "off"}`,
+        "",
+        "**Sandboxing:**",
+        `  Sandboxed session: ${sandboxActive() ? `yes (${process.env.PI_TOOLS_ARE_SANDBOXED ? "declared" : "auto-detected"})` : "no"}`,
+        `  apply_patch: ${applyPatchEnabled() ? (applyPatchBlocked() ? "registered but blocked (sandbox)" : "on") : "off"}`,
         "",
         "**Leaked content cleaning:** always on for detected families",
         `**Repairs:** ${[...repairCounts.values()].reduce((a, b) => a + b, 0)} total`,
@@ -319,7 +293,6 @@ export default function (pi: ExtensionAPI) {
   pi.on("session_start", (_event, ctx) => {
     sessionModel = ctx.model ? { id: ctx.model.id, provider: ctx.model.provider } : undefined;
     activeFamily = null;
-    repairThisTurn = false;
     hasErrorThisTurn = false;
     lastErrorInfo = null;
     remindedThisTurn = false;
@@ -334,7 +307,10 @@ export default function (pi: ExtensionAPI) {
     cacheStats.hitTurns = 0;
     cacheStats.missTurns = 0;
     pendingGuidance = undefined;
-    debugLog("session_start:", ctx.model?.provider, ctx.model?.id);
+    const tools = pi.getAllTools();
+    toolSnapshot = tools.map((t) => ({ name: t.name, sourceInfo: t.sourceInfo }));
+    schemaByName = new Map(tools.filter((t) => SCHEMA_TOOL_NAMES.has(t.name)).map((t) => [t.name, t.parameters]));
+    debugLog("session_start:", ctx.model?.provider, ctx.model?.id, sandboxActive() ? "(sandboxed session: extension-owned host tools)" : "");
   });
 
   // ── before_agent_start: repair flag + error hints + DeepSeek guidance ──
@@ -352,7 +328,6 @@ export default function (pi: ExtensionAPI) {
   // byte-identical per session, therefore cache-safe.
   pi.on("before_agent_start", (event, ctx) => {
     activeFamily = family(ctx.model);
-    repairThisTurn = activeFamily !== null && repairEnabled();
     remindedThisTurn = false;
 
     if (!activeFamily) { debugLog("guidance: skipped (no family detected)"); return; }
@@ -391,14 +366,18 @@ export default function (pi: ExtensionAPI) {
     let systemPrompt = event.systemPrompt;
 
     // apply_patch preference — all DeepSeek V4 (flash+pro); GLM excluded per
-    // eval. Eval (2026-07-29, 15 trials, 3 targets) showed all models use edit
-    // with zero edit_mismatch errors. DeepSeek keeps guidance as a safety net
-    // for real-world multi-file/frontmatter edits beyond the eval's scope; GLM
+    // eval. Skipped while our apply_patch is hard-blocked in a sandboxed
+    // session (a preference hint would steer the model into a blocked call).
+    // When the live apply_patch is another extension's (e.g. a sandbox's
+    // VM-routed tool), it is usable, so the hint still fires. Eval
+    // (2026-07-29, 15 trials, 3 targets) showed all models use edit with zero
+    // edit_mismatch errors. DeepSeek keeps guidance as a safety net for
+    // real-world multi-file/frontmatter edits beyond the eval's scope; GLM
     // excluded because it doesn't receive the suite of DeepSeek-specific
     // steering (Super Power, selection guidance, semantic-miss blocking) and
     // thus doesn't need the companion hint. Static per session (depends only
     // on the active-tool set).
-    if (activeFamily === "deepseek-v4") {
+    if (activeFamily === "deepseek-v4" && !applyPatchBlocked()) {
       const patchHint = applyPatchPreferenceGuidance(activeForHint);
       if (patchHint) systemPrompt = `${systemPrompt}\n\n${patchHint}`;
     }
@@ -462,76 +441,67 @@ export default function (pi: ExtensionAPI) {
     if (payload !== event.payload) return payload;
   });
 
-  // ── tool_execution_end: categorize errors ──
-  pi.on("tool_execution_end", (event, ctx) => {
-    if (!event.isError || !family(ctx.model)) return;
-    hasErrorThisTurn = true;
-    const info = categorizeToolError(event.toolName, event.result);
-    lastErrorInfo = info;
-    recordError(event.toolName, info.category);
-    logWarn(event.toolName, info.category);
-  });
+  // ── tool_call: sandbox gate + dangerous guard (all families), argument repair
+  //    + edit pre-flight (all families), steering (DeepSeek only) ──
+  //
+  // Tool interception happens HERE via the SDK's mutable-input tool_call hook
+  // instead of re-registering the built-in tools (re-registering would make the
+  // host resolve the name against other tool-owning extensions such as a
+  // sandbox, in registration order). The hook fires before any registered tool
+  // executes, so the repair/pre-flight compose with whoever owns the tool.
+  pi.on("tool_call", async (event, ctx) => {
+    // Sandbox gate — load-order independent and extension-agnostic: apply_patch
+    // writes raw node:fs anywhere, so it must never run while a sandboxing
+    // extension owns the host file tools AND the live apply_patch is ours (a
+    // sandbox-owned apply_patch is VM-routed and safe).
+    if (applyPatchBlocked() && event.toolName === "apply_patch") {
+      return { block: true, reason: "apply_patch writes directly to the host filesystem and is disabled while a sandboxing extension owns the host file tools. Use edit instead." };
+    }
 
-  // ── message_end: detect reasoning-accumulation 400s (provider rejects the
-  //    request once prior reasoning_content grows too large). Feeds the shared
-  //    error-hint path so the NEXT turn's user message carries the actionable
-  //    fix (set PI_MODEL_TOOLS_STRIP_REASONING=1). Only fires on the
-  //    stopReason === "error" assistant message, so it never double-counts
-  //    normal tool errors (those arrive via tool_execution_end).
-  pi.on("message_end", (event, ctx) => {
-    if (!family(ctx.model)) return;
-    const msg = event.message as { role?: string; stopReason?: string; errorMessage?: string };
-    if (msg.role !== "assistant" || msg.stopReason !== "error") return;
-    const errorText = String(msg.errorMessage ?? "");
-    if (!detectReasoningRejection(errorText)) return;
-    hasErrorThisTurn = true;
-    lastErrorInfo = {
-      category: "reasoning_rejected",
-      toolName: "provider",
-      hint: "The provider rejected this request, likely due to accumulated reasoning_content in prior turns (or a content-length overflow). Set PI_MODEL_TOOLS_STRIP_REASONING=1 (optionally PI_MODEL_TOOLS_REASONING_MAX_CHARS=4096) and retry.",
-    };
-    recordError("provider", "reasoning_rejected");
-    logWarn("provider", "reasoning_rejected");
-  });
-
-  // ── agent_end ──
-  pi.on("agent_end", () => { repairThisTurn = false; debugLog("agent_end: flags reset"); });
-
-  // ── turn_end: accumulate prompt-cache usage for /model-tools-status ──
-  pi.on("turn_end", (event) => {
-    // turn_end fires once per assistant LLM call (agent-loop emits per round),
-    // so each message.usage is a single API call — no double-counting.
-    if (event.message.role !== "assistant") return;
-    const usage = event.message.usage;
-    if (!usage) return;
-    const input = usage.input;
-    const cacheRead = usage.cacheRead;
-    const cacheWrite = usage.cacheWrite;
-    if (input === 0 && cacheRead === 0 && cacheWrite === 0) return;
-    cacheStats.input += input;
-    cacheStats.cacheRead += cacheRead;
-    cacheStats.cacheWrite += cacheWrite;
-    // A turn with only cacheWrite (first turn of a session) is a miss: the
-    // prefix was computed and written, not read back from cache.
-    if (cacheRead > 0) cacheStats.hitTurns++;
-    else cacheStats.missTurns++;
-  });
-
-  // ── tool_call: dangerous guard (all families) + steering (DeepSeek only) ──
-  pi.on("tool_call", (event, ctx) => {
     const f = family(ctx.model);
-    if (!f) return;
 
-    // Dangerous command guard — all families
+    // Dangerous command guard — all families.
     if (event.toolName === "bash" && blockDangerousEnabled()) {
       const command = isRecord(event.input) ? event.input.command : undefined;
       const danger = typeof command === "string" ? checkDangerousCommand(command) : undefined;
       if (danger) { logWarn("DANGEROUS:", danger); return { block: true, reason: `Safety: ${danger}` }; }
     }
 
+    // Argument repair + edit pre-flight — all families (argument repair gated
+    // on detected family + config; decontamination and pre-flight are safe,
+    // deterministic fixes and run unconditionally).
+    if (event.toolName === "edit" && isRecord(event.input)) {
+      // Strip read-tool contamination from oldText (always on — it's a safe,
+      // deterministic fix for the documented mismatch root cause).
+      if (decontaminateEditArgs(event.input)) onRepair("edit");
+      // Pre-flight indentation-drift correction: rewrite oldText to the file's
+      // real bytes when there is exactly one trim-tolerant match, so the exact
+      // matcher succeeds on the first (only) execution.
+      if (typeof event.input.path === "string") {
+        const fileContent = await readFileForRetry(event.input.path, ctx?.cwd || process.cwd());
+        if (fileContent !== null) {
+          const edits = Array.isArray(event.input.edits) ? event.input.edits : [];
+          if (edits.length > 0) {
+            const preflight = computePreflightEdits(fileContent, edits);
+            if (preflight) { event.input.edits = preflight.fixedEdits; onRepair("edit"); }
+          }
+        }
+      }
+    }
+    if (SCHEMA_TOOL_NAMES.has(event.toolName) && f && repairEnabled()) {
+      const schema = schemaByName.get(event.toolName)
+        ?? pi.getAllTools().find((t) => t.name === event.toolName)?.parameters;
+      if (schema !== undefined) {
+        const repaired = repairToolArguments(event.toolName, schema, event.input);
+        if (repaired.repaired && applyRepairInPlace(event.input, repaired.args)) {
+          onRepair(event.toolName);
+        }
+      }
+    }
+
     if (event.toolName.startsWith("serena_")) { remindedThisTurn = false; return; }
 
-    // Read-on-guessed-path — all families (correctness)
+    // Read-on-guessed-path — all families (correctness).
     if (event.toolName === "read" && isRecord(event.input) && ctx.cwd) {
       const filePath = typeof event.input.path === "string" ? event.input.path.trim() : "";
       if (filePath && looksLikeCodePath(filePath) && !existsSync(resolvePath(ctx.cwd, filePath))) {
@@ -584,5 +554,80 @@ export default function (pi: ExtensionAPI) {
     if (remindedThisTurn) return;
     remindedThisTurn = true;
     pi.sendMessage({ customType: "model-tools-reminder", content: `${reason} Use bash for real commands only.`, display: true }, { deliverAs: "steer" });
+  });
+
+  // ── tool_result: enrich unresolvable edit mismatches with the nearest region
+  //    (replaces the former execute-wrapper rethrow). Model-facing only — error
+  //    categorization below still sees the original error text. ──
+  pi.on("tool_result", async (event, ctx) => {
+    if (event.toolName !== "edit" || !event.isError) return;
+    const text = Array.isArray(event.content)
+      ? event.content.map((p) => isRecord(p) && typeof p.text === "string" ? p.text : "").join("\n")
+      : "";
+    if (!isEditMismatchError(text)) return;
+    const input = isRecord(event.input) ? event.input : undefined;
+    if (!input || typeof input.path !== "string") return;
+    const edits = Array.isArray(input.edits) ? input.edits : [];
+    if (edits.length === 0) return;
+    const fileContent = await readFileForRetry(input.path, ctx?.cwd || process.cwd());
+    if (fileContent === null) return;
+    const enriched = editErrorEnrichment(fileContent, text, edits);
+    if (!enriched) return;
+    return { content: [{ type: "text", text: enriched }] };
+  });
+
+  // ── tool_execution_end: categorize errors ──
+  pi.on("tool_execution_end", (event, ctx) => {
+    if (!event.isError || !family(ctx.model)) return;
+    hasErrorThisTurn = true;
+    // In sandboxed sessions, permission denials are surfaced as ENOENT — pass
+    // the flag so the hint steers to access-granting recovery instead of
+    // "find first" (request_access is only suggested when actually present).
+    const info = categorizeToolError(event.toolName, event.result, { sandboxed: sandboxActive(), hasRequestAccess: hasRequestAccessTool() });
+    lastErrorInfo = info;
+    recordError(event.toolName, info.category);
+    logWarn(event.toolName, info.category);
+  });
+
+  // ── message_end: detect reasoning-accumulation 400s (provider rejects the
+  //    request once prior reasoning_content grows too large). Feeds the shared
+  //    error-hint path so the NEXT turn's user message carries the actionable
+  //    fix (set PI_MODEL_TOOLS_STRIP_REASONING=1). Only fires on the
+  //    stopReason === "error" assistant message, so it never double-counts
+  //    normal tool errors (those arrive via tool_execution_end).
+  pi.on("message_end", (event, ctx) => {
+    if (!family(ctx.model)) return;
+    const msg = event.message as { role?: string; stopReason?: string; errorMessage?: string };
+    if (msg.role !== "assistant" || msg.stopReason !== "error") return;
+    const errorText = String(msg.errorMessage ?? "");
+    if (!detectReasoningRejection(errorText)) return;
+    hasErrorThisTurn = true;
+    lastErrorInfo = {
+      category: "reasoning_rejected",
+      toolName: "provider",
+      hint: "The provider rejected this request, likely due to accumulated reasoning_content in prior turns (or a content-length overflow). Set PI_MODEL_TOOLS_STRIP_REASONING=1 (optionally PI_MODEL_TOOLS_REASONING_MAX_CHARS=4096) and retry.",
+    };
+    recordError("provider", "reasoning_rejected");
+    logWarn("provider", "reasoning_rejected");
+  });
+
+  // ── turn_end: accumulate prompt-cache usage for /model-tools-status ──
+  pi.on("turn_end", (event) => {
+    // turn_end fires once per assistant LLM call (agent-loop emits per round),
+    // so each message.usage is a single API call — no double-counting.
+    if (event.message.role !== "assistant") return;
+    const usage = event.message.usage;
+    if (!usage) return;
+    const input = usage.input;
+    const cacheRead = usage.cacheRead;
+    const cacheWrite = usage.cacheWrite;
+    if (input === 0 && cacheRead === 0 && cacheWrite === 0) return;
+    cacheStats.input += input;
+    cacheStats.cacheRead += cacheRead;
+    cacheStats.cacheWrite += cacheWrite;
+    // A turn with only cacheWrite (first turn of a session) is a miss: the
+    // prefix was computed and written, not read back from cache.
+    if (cacheRead > 0) cacheStats.hitTurns++;
+    else cacheStats.missTurns++;
   });
 }

--- a/pi-model-tools/extensions/lib/edit-repair.ts
+++ b/pi-model-tools/extensions/lib/edit-repair.ts
@@ -8,7 +8,8 @@
  *  2. leading-whitespace drift: pi's matcher normalizes trailing whitespace
  *     only; Codex's seek_sequence also tolerates leading-ws differences.
  *
- * Pure + testable. The wiring (prepareArguments/execute) lives in index.ts.
+ * Pure + testable. The wiring (tool_call pre-flight + tool_result enrichment
+ * hooks) lives in index.ts.
  */
 
 /** Strip a UTF-8 BOM if present. */
@@ -115,6 +116,54 @@ export function computeRetryEdit(fileContent: string, edits: { oldText: string; 
   const realOld = fileBytesForBlock(fileContent, firstIndex, patternLines.length);
   const fixedEdits = edits.map((e, i) => i === idx ? { ...e, oldText: realOld } : e);
   return { fixedEdits };
+}
+
+/**
+ * Pre-flight indentation-drift correction for the `edit` tool. For every edit,
+ * if there is exactly ONE trim-tolerant match whose real file bytes differ from
+ * the (decontaminated) oldText, rebuild that oldText from the file's bytes so
+ * the core exact matcher succeeds. Edits that already match, or whose match is
+ * ambiguous/absent, are left untouched (the tool reports those normally and the
+ * error is enriched via editErrorEnrichment). Returns null when nothing changed.
+ *
+ * This replaces the execute-level catch-and-retry (index.ts wrapper): it runs
+ * in the tool_call hook BEFORE the sandboxed edit executes, so it also works
+ * for extensions that own the edit tool (e.g. a sandbox's VM-wrapped edit).
+ */
+export function computePreflightEdits(fileContent: string, edits: { oldText: string; newText: string }[]): { fixedEdits: { oldText: string; newText: string }[] } | null {
+  let changed = false;
+  const fixedEdits = edits.map((edit, i) => {
+    const oldText = typeof edit?.oldText === "string" ? edit.oldText : "";
+    if (!oldText) return edit;
+    const decontaminated = stripReadContamination(oldText).text;
+    const { count, firstIndex } = findTrimMatch(fileContent, decontaminated);
+    if (count !== 1) return edit;
+    const patternLines = decontaminated.split("\n");
+    if (patternLines.length > 1 && patternLines[patternLines.length - 1] === "") patternLines.pop();
+    const realOld = fileBytesForBlock(fileContent, firstIndex, patternLines.length);
+    if (realOld === decontaminated) return edit;
+    changed = true;
+    return { ...edit, oldText: realOld };
+  });
+  return changed ? { fixedEdits } : null;
+}
+
+/**
+ * Enrich an edit mismatch error with the nearest numbered file region so the
+ * model can copy verbatim on the next turn. Returns undefined when the error is
+ * not a mismatch, the failing edit is unknown, or no region can be computed.
+ * Used by the tool_result hook (replaces the execute wrapper's rethrown error).
+ */
+export function editErrorEnrichment(fileContent: string, errorText: string, edits: { oldText: string; newText: string }[]): string | undefined {
+  if (!isEditMismatchError(errorText)) return undefined;
+  if (edits.length === 0) return undefined;
+  const idx = Math.min(parseFailedEditIndex(errorText), edits.length - 1);
+  const failing = edits[idx];
+  const oldText = typeof failing?.oldText === "string" ? failing.oldText : "";
+  if (!oldText) return undefined;
+  const nearest = nearestBlock(fileContent, stripReadContamination(oldText).text);
+  if (!nearest) return undefined;
+  return `${errorText}\n\n${nearest}`;
 }
 
 /**

--- a/pi-model-tools/extensions/lib/model-detection.ts
+++ b/pi-model-tools/extensions/lib/model-detection.ts
@@ -57,3 +57,57 @@ export function autoBlockAfterReminders(env: Record<string, string | undefined> 
 export function blockDangerousEnabled(env: Record<string, string | undefined> = process.env): boolean {
   return !/^(0|false|no|off)$/i.test(env.PI_MODEL_TOOLS_BLOCK_DANGEROUS_COMMANDS ?? "");
 }
+
+/**
+ * Whether the `apply_patch` tool may be registered. Default ON. Set to
+ * 0/false/off to skip registration entirely (belt-and-suspenders on top of the
+ * runtime sandbox gate: apply_patch writes raw node:fs anywhere and is blocked
+ * when a sandboxing extension owns the host file tools).
+ */
+export function applyPatchEnabled(env: Record<string, string | undefined> = process.env): boolean {
+  return !/^(0|false|no|off)$/i.test(env.PI_MODEL_TOOLS_APPLY_PATCH ?? "");
+}
+
+// ── Sandbox detection ──
+
+/**
+ * Host built-in tools that a VM-style sandboxing extension re-registers to
+ * route calls through its sandbox. If an extension owns any of these names, the
+ * host tools are sandboxed.
+ */
+const SANDBOXED_HOST_TOOLS = new Set(["read", "write", "edit", "bash"]);
+
+/** Minimal tool shape needed by isSandboxed (subset of the host's ToolInfo). */
+export interface ToolSourceInfoLike {
+  name: string;
+  sourceInfo?: { source?: string } | null;
+}
+
+/**
+ * Whether the host's built-in file tools are sandboxed (VM-wrapped) by another
+ * extension.
+ *
+ * `PI_TOOLS_ARE_SANDBOXED` is the shared declared-override convention — set it
+ * in a sandbox extension's module top-level (all extension modules load before
+ * `session_start`, so the value is visible regardless of load order):
+ *   - 1/true/yes/on  → sandboxed
+ *   - 0/false/no/off → not sandboxed (overrides auto-detection)
+ *   - unset          → auto-detect: a sandboxing extension re-registers a host
+ *     built-in tool name and wins the host's first-registration-per-name
+ *     resolution, so `read`/`write`/`edit`/`bash` then carry a non-"builtin"
+ *     `sourceInfo.source`.
+ */
+export function isSandboxed(
+  env: Record<string, string | undefined> = process.env,
+  tools?: readonly ToolSourceInfoLike[],
+): boolean {
+  const declared = env.PI_TOOLS_ARE_SANDBOXED;
+  if (declared !== undefined && declared !== "") {
+    if (/^(1|true|yes|on)$/i.test(declared)) return true;
+    if (/^(0|false|no|off)$/i.test(declared)) return false;
+  }
+  if (!tools) return false;
+  return tools.some(
+    (t) => SANDBOXED_HOST_TOOLS.has(t.name) && t.sourceInfo?.source !== undefined && t.sourceInfo.source !== "builtin",
+  );
+}

--- a/pi-model-tools/extensions/lib/shell-helpers.ts
+++ b/pi-model-tools/extensions/lib/shell-helpers.ts
@@ -193,7 +193,7 @@ export function detectReasoningRejection(errorText: string): boolean {
   return false;
 }
 
-export function categorizeToolError(toolName: string, errorResult: unknown): ErrorInfo {
+export function categorizeToolError(toolName: string, errorResult: unknown, opts?: { sandboxed?: boolean; hasRequestAccess?: boolean }): ErrorInfo {
   const text = (isRecord(errorResult) && Array.isArray(errorResult.content)
     ? errorResult.content.map((p) => isRecord(p) && typeof p.text === "string" ? p.text : "").join("\n")
     : String(errorResult ?? "")).toLowerCase();
@@ -205,7 +205,18 @@ export function categorizeToolError(toolName: string, errorResult: unknown): Err
   if (/rate limit|429|too many requests|exceeded.*limit/i.test(text)) return { category: "rate_limit", toolName, hint: "Rate-limited. Wait before retrying or simplify the request." };
   if (/timed? ?out|timeout/i.test(text)) return { category: "timeout", toolName, hint: "Timed out. Use simpler inputs or reduce scope." };
   if (/validation failed|invalid_type|required|missing.*(field|argument|property)/i.test(text)) return { category: "validation", toolName, hint: "Invalid arguments. Provide all required fields with correct types." };
-  if (/enoent|no such file or directory|(?:file|path) not found/i.test(text)) return { category: "path_not_found", toolName, hint: "Path missing or guessed. Discover the exact path with find first." };
+  if (/enoent|no such file or directory|(?:file|path) not found/i.test(text)) return {
+    category: "path_not_found",
+    toolName,
+    // Sandboxed sessions deliberately surface permission-denied paths as ENOENT
+    // to hide their existence; "find first" would misdirect. Steer to the
+    // sandbox's access-granting tool only when it is actually available.
+    hint: opts?.sandboxed
+      ? (opts.hasRequestAccess
+        ? "Path not visible in this sandbox — it may exist but be permission-denied. Call request_access to grant the path, then retry."
+        : "Path not visible in this sandbox — it may exist but be permission-denied. Grant access to the path in the sandbox, then retry.")
+      : "Path missing or guessed. Discover the exact path with find first.",
+  };
   if (/no such tool|unknown tool|is not a function|tool\s+\S+\s+(?:was\s+)?not found/i.test(text)) return { category: "tool_not_found", toolName, hint: "Use only exact Pi tool names. Never invent names like read_file." };
   if (/(?:http(?: status)?|status(?: code)?|api(?: error)?)[^\n]{0,20}[45]\d{2}\b|\b[45]\d{2}\s+(?:bad request|unauthorized|forbidden|not found|conflict|too many requests|internal server error|bad gateway|service unavailable|gateway timeout)\b/i.test(text)) return { category: "api_error", toolName, hint: `Tool call to ${toolName} failed. Retry with simpler inputs.` };
   return { category: "unknown", toolName, hint: "Previous tool call(s) had errors. Use simpler inputs." };

--- a/pi-model-tools/extensions/test/unit/edit-repair.test.ts
+++ b/pi-model-tools/extensions/test/unit/edit-repair.test.ts
@@ -8,6 +8,8 @@ import {
   parseFailedEditIndex,
   isEditMismatchError,
   computeRetryEdit,
+  computePreflightEdits,
+  editErrorEnrichment,
   stripBom,
   normalizeToLF,
 } from "../../lib/edit-repair.ts";
@@ -193,5 +195,91 @@ describe("computeRetryEdit", () => {
     const r = computeRetryEdit(fileContent, [{ oldText: "a\nb\n", newText: "A\nB\n" }], 0);
     assert.ok(r);
     assert.equal(r!.fixedEdits[0].oldText, "a\nb");
+  });
+});
+
+describe("computePreflightEdits", () => {
+  it("rewrites indentation-drifted oldText to the file's real bytes when exactly one trim match exists", () => {
+    const fileContent = "  a\n    b\n  c";
+    const edits = [{ oldText: "a\nb", newText: "A\nB" }];
+    const r = computePreflightEdits(fileContent, edits);
+    assert.ok(r, "expected a pre-flight result");
+    assert.equal(r!.fixedEdits[0].oldText, "  a\n    b");
+    assert.equal(r!.fixedEdits[0].newText, "A\nB");
+  });
+
+  it("returns null when nothing needs fixing (exact match)", () => {
+    const r = computePreflightEdits("  a\n  b", [{ oldText: "  a", newText: "A" }]);
+    assert.equal(r, null);
+  });
+
+  it("returns null when the trim match is ambiguous (count > 1)", () => {
+    const r = computePreflightEdits("x\nx\nx", [{ oldText: "x", newText: "y" }]);
+    assert.equal(r, null);
+  });
+
+  it("returns null when there is no trim match (count 0)", () => {
+    const r = computePreflightEdits("a\nb", [{ oldText: "zzz", newText: "y" }]);
+    assert.equal(r, null);
+  });
+
+  it("returns null when oldText is missing/empty", () => {
+    const r = computePreflightEdits("a\nb", [{ oldText: "", newText: "y" }]);
+    assert.equal(r, null);
+  });
+
+  it("only rewrites the edits that drifted, leaving exact edits untouched", () => {
+    const fileContent = "one\n  two\nthree";
+    const edits = [
+      { oldText: "one", newText: "ONE" },
+      { oldText: "two", newText: "TWO" }, // indentation drifted vs file's "  two"
+    ];
+    const r = computePreflightEdits(fileContent, edits);
+    assert.ok(r);
+    assert.equal(r!.fixedEdits[0].oldText, "one");      // untouched
+    assert.equal(r!.fixedEdits[1].oldText, "  two");    // rebuilt
+    assert.equal(r!.fixedEdits[1].newText, "TWO");
+  });
+});
+
+describe("editErrorEnrichment", () => {
+  const content = "alpha\nbeta\ngamma\ndelta";
+
+  it("returns undefined for non-mismatch errors", () => {
+    assert.equal(editErrorEnrichment(content, "Operation aborted", [{ oldText: "beta", newText: "B" }]), undefined);
+  });
+
+  it("returns undefined for empty edits array", () => {
+    assert.equal(editErrorEnrichment(content, "Could not find the exact text in x.", []), undefined);
+  });
+
+  it("returns undefined when the failing edit has no oldText", () => {
+    const r = editErrorEnrichment(content, "Could not find the exact text in x.", [{ oldText: "", newText: "B" }]);
+    assert.equal(r, undefined);
+  });
+
+  it("appends the nearest numbered region to a mismatch error", () => {
+    const enriched = editErrorEnrichment(content, "Could not find the exact text in x.", [{ oldText: "beta\ngamma", newText: "B\nG" }]);
+    assert.ok(enriched);
+    assert.match(enriched!, /Could not find the exact text/);
+    assert.match(enriched!, /Nearest matching region/);
+    assert.match(enriched!, /\| beta/);
+  });
+
+  it("uses the edits[N] index from the error for multi-edit arrays", () => {
+    const edits = [
+      { oldText: "alpha", newText: "A" },
+      { oldText: "gamma", newText: "G" },
+    ];
+    const enriched = editErrorEnrichment(content, "Could not find edits[1] in x.", edits);
+    assert.ok(enriched);
+    assert.match(enriched!, /\| gamma/);
+  });
+
+  it("clamps an out-of-range index to the last edit", () => {
+    const edits = [{ oldText: "beta", newText: "B" }];
+    const enriched = editErrorEnrichment(content, "Could not find edits[9] in x.", edits);
+    assert.ok(enriched);
+    assert.match(enriched!, /\| beta/);
   });
 });

--- a/pi-model-tools/extensions/test/unit/index.test.ts
+++ b/pi-model-tools/extensions/test/unit/index.test.ts
@@ -1,0 +1,342 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import extension from "../../index.ts";
+
+// Stub harness: the extension must compose with the host's OWN tool
+// registrations, so this fake ExtensionAPI records what pi-model-tools
+// registers and lets tests drive the hooks it subscribed to. Host built-ins
+// carry sourceInfo.source === "builtin"; apply_patch defaults to our package
+// identity. Options simulate a sandboxing extension: `withSandbox` makes it own
+// the host file tools, `withForeignApplyPatch` makes the live apply_patch
+// belong to the sandbox (host first-registration-per-name), `withRequestAccess`
+// adds the access-granting tool.
+function createHarness(opts: { withSandbox?: boolean; withForeignApplyPatch?: boolean; withRequestAccess?: boolean } = {}) {
+  const registeredTools: string[] = [];
+  const commands: Record<string, unknown> = {};
+  const handlers = new Map<string, Array<(...args: unknown[]) => unknown>>();
+  const sentMessages: Array<{ type: string; content: string }> = [];
+
+  const readSchema = Type.Object({ path: Type.String(), offset: Type.Optional(Type.Integer()), limit: Type.Optional(Type.Integer()) });
+  const writeSchema = Type.Object({ path: Type.String(), content: Type.String() });
+  const editSchema = Type.Object({ path: Type.String(), edits: Type.Array(Type.Object({ oldText: Type.String(), newText: Type.String() })) });
+  const genericSchema = Type.Object({ pattern: Type.String(), path: Type.String() });
+  const schemas: Record<string, unknown> = { read: readSchema, write: writeSchema, edit: editSchema, grep: genericSchema, find: genericSchema, ls: genericSchema, bash: Type.Object({ command: Type.String() }) };
+
+  const toolInfos: unknown[] = [];
+  const base = ["read", "write", "edit", "grep", "find", "ls", "bash", "apply_patch"];
+  const hostBuiltins = new Set(["read", "write", "edit", "grep", "find", "ls", "bash"]);
+  if (opts.withRequestAccess) base.push("request_access");
+  for (const name of base) {
+    let source = hostBuiltins.has(name) ? "builtin" : "@bacnh85/pi-model-tools";
+    if (hostBuiltins.has(name) && opts.withSandbox) source = "some-sandbox";
+    if (name === "apply_patch" && opts.withForeignApplyPatch) source = "some-sandbox";
+    toolInfos.push({
+      name,
+      description: name,
+      parameters: schemas[name],
+      promptGuidelines: [],
+      promptSnippet: name,
+      sourceInfo: { source },
+    });
+  }
+
+  const pi = {
+    on: (event: string, handler: (...args: unknown[]) => unknown) => {
+      const list = handlers.get(event) ?? [];
+      list.push(handler);
+      handlers.set(event, list);
+    },
+    registerTool: (tool: { name: string }) => { registeredTools.push(tool.name); },
+    registerCommand: (name: string, options: unknown) => { commands[name] = options; },
+    getAllTools: () => toolInfos,
+    getActiveTools: () => base,
+    sendMessage: (msg: { customType: string; content: unknown }) => { sentMessages.push({ type: msg.customType, content: String(msg.content) }); },
+  } as unknown as ExtensionAPI;
+
+  return {
+    pi,
+    registeredTools,
+    commands,
+    sentMessages,
+    emit: async (event: string, ...args: unknown[]): Promise<unknown[]> => {
+      const out: unknown[] = [];
+      for (const h of handlers.get(event) ?? []) out.push(await (h as (...a: unknown[]) => unknown)(...args));
+      return out;
+    },
+  };
+}
+
+async function withEnv(env: Record<string, string | undefined>, fn: () => Promise<void> | void) {
+  const saved = new Map<string, string | undefined>();
+  for (const [k, v] of Object.entries(env)) { saved.set(k, process.env[k]); process.env[k] = v; }
+  try { await fn(); } finally { for (const [k] of Object.entries(env)) process.env[k] = saved.get(k); }
+}
+
+describe("pi-model-tools hook-only registration", () => {
+  it("does NOT re-register the built-in tools (only apply_patch by default)", async () => {
+    await withEnv({ PI_MODEL_TOOLS_APPLY_PATCH: "1" }, () => {
+      const h = createHarness();
+      extension(h.pi);
+      assert.deepStrictEqual([...h.registeredTools].sort(), ["apply_patch"]);
+    });
+  });
+
+  it("skips apply_patch registration when PI_MODEL_TOOLS_APPLY_PATCH=0", async () => {
+    await withEnv({ PI_MODEL_TOOLS_APPLY_PATCH: "0" }, () => {
+      const h = createHarness();
+      extension(h.pi);
+      assert.deepStrictEqual(h.registeredTools, []);
+    });
+  });
+
+  it("registers the /model-tools-status command", () => {
+    const h = createHarness();
+    extension(h.pi);
+    assert.ok(h.commands["model-tools-status"], "expected model-tools-status command");
+  });
+});
+
+describe("session_start sandbox detection (generic, extension-agnostic)", () => {
+  it("auto-detects a sandbox when an extension owns the host file tools", async () => {
+    await withEnv({ PI_MODEL_TOOLS_APPLY_PATCH: "1" }, async () => {
+      const h = createHarness({ withSandbox: true });
+      extension(h.pi);
+      await h.emit("session_start", {}, { model: { id: "deepseek-v4-flash", provider: "opencode-go" } });
+      const [result] = await h.emit("tool_call", { toolName: "apply_patch", input: { patch: "*** Begin Patch" } }, { cwd: process.cwd() });
+      assert.ok(result && typeof result === "object" && "block" in result, "expected a block result");
+      assert.strictEqual((result as { block: boolean }).block, true);
+    });
+  });
+
+  it("declares a sandbox via PI_TOOLS_ARE_SANDBOXED even without auto-detection", async () => {
+    await withEnv({ PI_MODEL_TOOLS_APPLY_PATCH: "1", PI_TOOLS_ARE_SANDBOXED: "1" }, async () => {
+      const h = createHarness();
+      extension(h.pi);
+      await h.emit("session_start", {}, { model: { id: "deepseek-v4-flash", provider: "opencode-go" } });
+      const [result] = await h.emit("tool_call", { toolName: "apply_patch", input: { patch: "*** Begin Patch" } }, { cwd: process.cwd() });
+      assert.strictEqual((result as { block: boolean }).block, true);
+    });
+  });
+
+  it("PI_TOOLS_ARE_SANDBOXED=0 overrides auto-detection", async () => {
+    await withEnv({ PI_MODEL_TOOLS_APPLY_PATCH: "1", PI_TOOLS_ARE_SANDBOXED: "0" }, async () => {
+      const h = createHarness({ withSandbox: true });
+      extension(h.pi);
+      await h.emit("session_start", {}, { model: { id: "deepseek-v4-flash", provider: "opencode-go" } });
+      const [result] = await h.emit("tool_call", { toolName: "apply_patch", input: { patch: "*** Begin Patch" } }, { cwd: process.cwd() });
+      assert.strictEqual(result, undefined);
+    });
+  });
+
+  it("allows apply_patch when no sandboxing extension is present", async () => {
+    const h = createHarness();
+    extension(h.pi);
+    await h.emit("session_start", {}, { model: { id: "deepseek-v4-flash", provider: "opencode-go" } });
+    const [result] = await h.emit("tool_call", { toolName: "apply_patch", input: { patch: "*** Begin Patch" } }, { cwd: process.cwd() });
+    assert.strictEqual(result, undefined);
+  });
+
+  it("does NOT block a sandbox-owned apply_patch (host first-registration-per-name)", async () => {
+    const h = createHarness({ withSandbox: true, withForeignApplyPatch: true });
+    extension(h.pi);
+    await h.emit("session_start", {}, { model: { id: "deepseek-v4-flash", provider: "opencode-go" } });
+    const [result] = await h.emit("tool_call", { toolName: "apply_patch", input: { patch: "*** Begin Patch" } }, { cwd: process.cwd() });
+    assert.strictEqual(result, undefined);
+  });
+
+  it("blocks apply_patch only AFTER session_start snapshotted the tools (load-order independence)", async () => {
+    const h = createHarness({ withSandbox: true });
+    extension(h.pi);
+    const [before] = await h.emit("tool_call", { toolName: "apply_patch", input: { patch: "x" } }, { cwd: process.cwd() });
+    assert.strictEqual(before, undefined, "no block before session_start snapshot");
+    await h.emit("session_start", {}, { model: { id: "deepseek-v4-flash", provider: "opencode-go" } });
+    const [after] = await h.emit("tool_call", { toolName: "apply_patch", input: { patch: "x" } }, { cwd: process.cwd() });
+    assert.strictEqual((after as { block: boolean }).block, true);
+  });
+});
+
+describe("apply_patch LLM steering in sandboxed sessions", () => {
+  const deepseekCtx = { model: { id: "deepseek-v4-flash", provider: "opencode-go" } };
+  const agentStartEvent = { systemPrompt: "BASE", prompt: "", systemPromptOptions: { selectedTools: [] } };
+
+  it("suppresses apply_patch guidance while OUR apply_patch is blocked in a sandbox", async () => {
+    await withEnv({ PI_MODEL_TOOLS_SELECTION_GUIDANCE: "0" }, async () => {
+      const h = createHarness({ withSandbox: true });
+      extension(h.pi);
+      await h.emit("session_start", {}, deepseekCtx);
+      const [result] = await h.emit("before_agent_start", agentStartEvent, deepseekCtx);
+      assert.strictEqual(result, undefined, "no system-prompt change when the only possible edit hint is suppressed");
+    });
+  });
+
+  it("still suggests a sandbox-owned apply_patch (usable, so guidance fires)", async () => {
+    await withEnv({ PI_MODEL_TOOLS_SELECTION_GUIDANCE: "0" }, async () => {
+      const h = createHarness({ withSandbox: true, withForeignApplyPatch: true });
+      extension(h.pi);
+      await h.emit("session_start", {}, deepseekCtx);
+      const [result] = await h.emit("before_agent_start", agentStartEvent, deepseekCtx);
+      const prompt = (result as { systemPrompt?: string } | undefined)?.systemPrompt ?? "";
+      assert.match(prompt, /apply_patch/);
+    });
+  });
+
+  it("suggests apply_patch normally outside a sandbox", async () => {
+    await withEnv({ PI_MODEL_TOOLS_SELECTION_GUIDANCE: "0" }, async () => {
+      const h = createHarness();
+      extension(h.pi);
+      await h.emit("session_start", {}, deepseekCtx);
+      const [result] = await h.emit("before_agent_start", agentStartEvent, deepseekCtx);
+      const prompt = (result as { systemPrompt?: string } | undefined)?.systemPrompt ?? "";
+      assert.match(prompt, /apply_patch/);
+    });
+  });
+});
+
+describe("tool_call edit pre-flight (in-place mutation)", () => {
+  it("rewrites indentation-drifted oldText to the file's real bytes", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pmt-prefly-"));
+    try {
+      const file = join(dir, "a.ts");
+      writeFileSync(file, "  a\n    b\n  c");
+      const h = createHarness();
+      extension(h.pi);
+      await h.emit("session_start", {}, { model: undefined });
+      const event = { toolName: "edit", input: { path: file, edits: [{ oldText: "a\nb", newText: "A\nB" }] } };
+      const [result] = await h.emit("tool_call", event, { cwd: dir, model: undefined });
+      assert.strictEqual(result, undefined, "pre-flight must not block");
+      assert.deepStrictEqual(event.input.edits[0].oldText, "  a\n    b");
+      assert.deepStrictEqual(event.input.edits[0].newText, "A\nB");
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+});
+
+describe("tool_call argument repair (in-place mutation)", () => {
+  it("repairs a degenerate markdown-link path on read", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pmt-repair-"));
+    try {
+      mkdirSync(join(dir, "src"), { recursive: true });
+      writeFileSync(join(dir, "src", "foo.ts"), "export const x = 1;\n");
+      const h = createHarness();
+      extension(h.pi);
+      await h.emit("session_start", {}, { model: { id: "deepseek-v4-flash", provider: "opencode-go" } });
+      const event = { toolName: "read", input: { path: "[src/foo.ts](https://src/foo.ts)", offset: 1, limit: 2000 } };
+      await withEnv({ PI_MODEL_TOOLS_REPAIR_ENABLED: "1" }, async () => {
+        const [result] = await h.emit("tool_call", event, { cwd: dir, model: undefined });
+        assert.strictEqual(result, undefined);
+      });
+      assert.strictEqual(event.input.path, "src/foo.ts");
+      assert.strictEqual(event.input.offset, 1);
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it("leaves valid args untouched (no repair side effects)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pmt-noop-"));
+    try {
+      mkdirSync(join(dir, "src"), { recursive: true });
+      writeFileSync(join(dir, "src", "foo.ts"), "export const x = 1;\n");
+      const h = createHarness();
+      extension(h.pi);
+      await h.emit("session_start", {}, { model: { id: "deepseek-v4-flash", provider: "opencode-go" } });
+      const event = { toolName: "read", input: { path: "src/foo.ts", offset: 1, limit: 2000 } };
+      await withEnv({ PI_MODEL_TOOLS_REPAIR_ENABLED: "1" }, async () => {
+        await h.emit("tool_call", event, { cwd: dir, model: undefined });
+      });
+      assert.deepStrictEqual(event.input, { path: "src/foo.ts", offset: 1, limit: 2000 });
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+});
+
+describe("tool_call dangerous-command guard", () => {
+  it("blocks `rm -rf /` on bash regardless of family", async () => {
+    await withEnv({ PI_MODEL_TOOLS_BLOCK_DANGEROUS_COMMANDS: "1" }, async () => {
+      const h = createHarness();
+      extension(h.pi);
+      const [result] = await h.emit("tool_call", { toolName: "bash", input: { command: "rm -rf /" } }, { cwd: process.cwd() });
+      assert.ok(result && (result as { block: boolean }).block, "expected a block");
+    });
+  });
+
+  it("does not block ordinary bash commands", async () => {
+    await withEnv({ PI_MODEL_TOOLS_BLOCK_DANGEROUS_COMMANDS: "1" }, async () => {
+      const h = createHarness();
+      extension(h.pi);
+      const [result] = await h.emit("tool_call", { toolName: "bash", input: { command: "git status" } }, { cwd: process.cwd() });
+      assert.strictEqual(result, undefined);
+    });
+  });
+});
+
+describe("tool_call read-on-guessed-path guard", () => {
+  it("blocks reading a non-existent code path and suggests find", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pmt-read-"));
+    try {
+      const h = createHarness();
+      extension(h.pi);
+      await h.emit("session_start", {}, { model: undefined });
+      const event = { toolName: "read", input: { path: "src/foo.ts", offset: 1, limit: 2000 } };
+      const [result] = await h.emit("tool_call", event, { cwd: dir, model: undefined });
+      assert.ok(result && (result as { block: boolean }).block);
+      assert.match((result as { reason: string }).reason, /Path not found/);
+      assert.match((result as { reason: string }).reason, /find/);
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+});
+
+describe("tool_result edit-error enrichment", () => {
+  it("appends the nearest region to an unresolvable mismatch", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pmt-enrich-"));
+    try {
+      const file = join(dir, "a.ts");
+      writeFileSync(file, "alpha\nbeta\ngamma\ndelta");
+      const h = createHarness();
+      extension(h.pi);
+      await h.emit("session_start", {}, { model: undefined });
+      const [result] = await h.emit("tool_result", {
+        toolName: "edit",
+        toolCallId: "t1",
+        input: { path: file, edits: [{ oldText: "beta\ngamma", newText: "B\nG" }] },
+        content: [{ type: "text", text: "Could not find the exact text in a.ts." }],
+        isError: true,
+        details: undefined,
+      }, { cwd: dir, model: undefined });
+      const content = (result as { content?: Array<{ text: string }> })?.content;
+      assert.ok(content && content[0]?.text, "expected enriched content");
+      assert.match(content[0].text, /Could not find the exact text/);
+      assert.match(content[0].text, /Nearest matching region/);
+      assert.match(content[0].text, /\| beta/);
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it("leaves non-mismatch results untouched", async () => {
+    const h = createHarness();
+    extension(h.pi);
+    const [result] = await h.emit("tool_result", {
+      toolName: "edit",
+      toolCallId: "t1",
+      input: { path: "a.ts", edits: [{ oldText: "beta", newText: "B" }] },
+      content: [{ type: "text", text: "updated a.ts" }],
+      isError: false,
+      details: undefined,
+    }, { cwd: process.cwd() });
+    assert.strictEqual(result, undefined);
+  });
+
+  it("leaves non-mismatch ERRORS untouched", async () => {
+    const h = createHarness();
+    extension(h.pi);
+    const [result] = await h.emit("tool_result", {
+      toolName: "edit",
+      toolCallId: "t1",
+      input: { path: "a.ts", edits: [{ oldText: "beta", newText: "B" }] },
+      content: [{ type: "text", text: "ENOENT: no such file or directory" }],
+      isError: true,
+      details: undefined,
+    }, { cwd: process.cwd() });
+    assert.strictEqual(result, undefined);
+  });
+});

--- a/pi-model-tools/extensions/test/unit/model-detection.test.ts
+++ b/pi-model-tools/extensions/test/unit/model-detection.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
-import { detectFamily, isRecord, repairEnabled, reasoningStripEnabled, blockDangerousEnabled, maxErrorHistory, autoBlockAfterReminders } from "../../lib/model-detection.ts";
+import { detectFamily, isRecord, repairEnabled, reasoningStripEnabled, blockDangerousEnabled, maxErrorHistory, autoBlockAfterReminders, applyPatchEnabled, isSandboxed } from "../../lib/model-detection.ts";
 
 describe("detectFamily", () => {
   const cases: Array<{ id: string; provider?: string; expected: string | null; label: string }> = [
@@ -38,6 +38,15 @@ describe("config helpers", () => {
   it("repairEnabled defaults to true", () => { assert.strictEqual(repairEnabled({}), true); assert.strictEqual(repairEnabled({ PI_MODEL_TOOLS_REPAIR_ENABLED: "0" }), false); });
   it("reasoningStripEnabled defaults to true (cache-stable for DeepSeek)", () => { assert.strictEqual(reasoningStripEnabled({}), true); assert.strictEqual(reasoningStripEnabled({ PI_MODEL_TOOLS_STRIP_REASONING: "0" }), false); assert.strictEqual(reasoningStripEnabled({ PI_MODEL_TOOLS_STRIP_REASONING: "off" }), false); });
   it("blockDangerousEnabled defaults to true", () => { assert.strictEqual(blockDangerousEnabled({}), true); assert.strictEqual(blockDangerousEnabled({ PI_MODEL_TOOLS_BLOCK_DANGEROUS_COMMANDS: "0" }), false); });
+  it("applyPatchEnabled defaults to true (opt-out via 0/false/off)", () => {
+    assert.strictEqual(applyPatchEnabled({}), true);
+    assert.strictEqual(applyPatchEnabled({ PI_MODEL_TOOLS_APPLY_PATCH: "0" }), false);
+    assert.strictEqual(applyPatchEnabled({ PI_MODEL_TOOLS_APPLY_PATCH: "false" }), false);
+    assert.strictEqual(applyPatchEnabled({ PI_MODEL_TOOLS_APPLY_PATCH: "no" }), false);
+    assert.strictEqual(applyPatchEnabled({ PI_MODEL_TOOLS_APPLY_PATCH: "off" }), false);
+    assert.strictEqual(applyPatchEnabled({ PI_MODEL_TOOLS_APPLY_PATCH: "1" }), true);
+    assert.strictEqual(applyPatchEnabled({ PI_MODEL_TOOLS_APPLY_PATCH: "true" }), true);
+  });
   it("maxErrorHistory defaults to 100", () => {
     assert.strictEqual(maxErrorHistory({}), 100);
     assert.strictEqual(maxErrorHistory({ PI_MODEL_TOOLS_MAX_ERROR_HISTORY: "200" }), 200);
@@ -54,5 +63,55 @@ describe("config helpers", () => {
     assert.strictEqual(autoBlockAfterReminders({ PI_MODEL_TOOLS_AUTO_BLOCK_AFTER_REMINDERS: "-3" }), 0);
     assert.strictEqual(autoBlockAfterReminders({ PI_MODEL_TOOLS_AUTO_BLOCK_AFTER_REMINDERS: "abc" }), 0);
     assert.strictEqual(autoBlockAfterReminders({ PI_MODEL_TOOLS_AUTO_BLOCK_AFTER_REMINDERS: "" }), 0);
+  });
+});
+
+describe("isSandboxed", () => {
+  const hostTools = [
+    { name: "read", sourceInfo: { source: "builtin" } },
+    { name: "write", sourceInfo: { source: "builtin" } },
+    { name: "edit", sourceInfo: { source: "builtin" } },
+    { name: "bash", sourceInfo: { source: "builtin" } },
+    { name: "ls", sourceInfo: { source: "builtin" } },
+    { name: "grep", sourceInfo: { source: "builtin" } },
+    { name: "find", sourceInfo: { source: "builtin" } },
+    { name: "apply_patch", sourceInfo: { source: "@bacnh85/pi-model-tools" } },
+  ];
+
+  it("declared 1/true/yes/on → sandboxed regardless of tools", () => {
+    assert.strictEqual(isSandboxed({ PI_TOOLS_ARE_SANDBOXED: "1" }), true);
+    assert.strictEqual(isSandboxed({ PI_TOOLS_ARE_SANDBOXED: "true" }, hostTools), true);
+    assert.strictEqual(isSandboxed({ PI_TOOLS_ARE_SANDBOXED: "yes" }), true);
+    assert.strictEqual(isSandboxed({ PI_TOOLS_ARE_SANDBOXED: "on" }), true);
+  });
+
+  it("declared 0/false/no/off → not sandboxed even with extension-owned host tools", () => {
+    const sandboxed = hostTools.map((t) => ({ ...t, sourceInfo: { source: "some-sandbox" } }));
+    assert.strictEqual(isSandboxed({ PI_TOOLS_ARE_SANDBOXED: "0" }, sandboxed), false);
+    assert.strictEqual(isSandboxed({ PI_TOOLS_ARE_SANDBOXED: "false" }, sandboxed), false);
+    assert.strictEqual(isSandboxed({ PI_TOOLS_ARE_SANDBOXED: "no" }, sandboxed), false);
+    assert.strictEqual(isSandboxed({ PI_TOOLS_ARE_SANDBOXED: "off" }, sandboxed), false);
+  });
+
+  it("unset + host-owned built-in tools → auto-detects the sandbox", () => {
+    const sandboxed = hostTools.map((t) => ({ ...t, sourceInfo: { source: "some-sandbox" } }));
+    assert.strictEqual(isSandboxed({}, sandboxed), true);
+    assert.strictEqual(isSandboxed({ PI_TOOLS_ARE_SANDBOXED: "" }, sandboxed), true);
+  });
+
+  it("unset + builtin-source tools → not sandboxed", () => {
+    assert.strictEqual(isSandboxed({}, hostTools), false);
+  });
+
+  it("unset + no tools or missing sourceInfo → not sandboxed", () => {
+    assert.strictEqual(isSandboxed({}), false);
+    assert.strictEqual(isSandboxed({}, [{ name: "read" }]), false);
+    assert.strictEqual(isSandboxed({}, [{ name: "read", sourceInfo: null }]), false);
+  });
+
+  it("only host file tools (read/write/edit/bash) count, not auxiliary tools", () => {
+    assert.strictEqual(isSandboxed({}, [{ name: "ls", sourceInfo: { source: "ext" } }]), false);
+    assert.strictEqual(isSandboxed({}, [{ name: "request_access", sourceInfo: { source: "ext" } }]), false);
+    assert.strictEqual(isSandboxed({}, [{ name: "bash", sourceInfo: { source: "ext" } }]), true);
   });
 });

--- a/pi-model-tools/extensions/test/unit/shell-helpers.test.ts
+++ b/pi-model-tools/extensions/test/unit/shell-helpers.test.ts
@@ -218,6 +218,25 @@ describe("categorizeToolError", () => {
     const info = categorizeToolError("read", "something weird happened");
     assert.equal(info.category, "unknown");
   });
+
+  it("steers a sandboxed ENOENT to request_access when that tool is present", () => {
+    const info = categorizeToolError("read", { content: [{ type: "text", text: "ENOENT: no such file or directory" }] }, { sandboxed: true, hasRequestAccess: true });
+    assert.equal(info.category, "path_not_found");
+    assert.match(info.hint, /request_access/);
+    assert.doesNotMatch(info.hint, /find first/);
+  });
+
+  it("gives generic access guidance for a sandboxed ENOENT without request_access", () => {
+    const info = categorizeToolError("read", { content: [{ type: "text", text: "ENOENT: no such file or directory" }] }, { sandboxed: true, hasRequestAccess: false });
+    assert.equal(info.category, "path_not_found");
+    assert.doesNotMatch(info.hint, /request_access/);
+    assert.match(info.hint, /Grant access/);
+  });
+
+  it("keeps the find-first hint outside a sandbox", () => {
+    const info = categorizeToolError("read", { content: [{ type: "text", text: "ENOENT: no such file or directory" }] }, { sandboxed: false });
+    assert.match(info.hint, /find first/);
+  });
 });
 
 describe("detectReasoningRejection", () => {

--- a/pi-model-tools/package-lock.json
+++ b/pi-model-tools/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bacnh85/pi-model-tools",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bacnh85/pi-model-tools",
-      "version": "0.5.3",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.19.43",

--- a/pi-model-tools/package.json
+++ b/pi-model-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bacnh85/pi-model-tools",
-  "version": "0.5.5",
+  "version": "0.6.0",
   "description": "Unified tool-wrapping, argument repair, reasoning management, DeepSeek V4 guidance + Super Power Mode, defensive leak-cleaning, edit mismatch repair (read-notice stripping + trim-tolerant retry), and a Codex-style apply_patch diff tool for DeepSeek V4 and GLM model families from any provider.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
(Also fixes README.md about Super Power Mode being off by default after 0.5.2.)

I've changed the approach on tool wrapping. What this extension does can be done with just the callback that can modify parameters and block the tool call, without the need to remove and re-define all tools.

I need this for an extension that I'm developing that runs the tools inside a VM, so I need to re-declare them, and this would make the two extensions incompatible.

I've also added the possibility to handle the case in which an apply_patch tool already exist or the case in which some extension declares that the tools are in a vm, not adding the apply_tool for this extension because it would circumvent the vm. Probably it could be possible to implement it as a call to the bash tool.