### PR TITLE
security(pi-evolve): add base_url validation to prevent open redirect attacks

### DIFF
--- a/pi-a2a/.gitignore
+++ b/pi-a2a/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .env.*
 .tmp-*.cjs
+.serena/

--- a/pi-evolve/CHANGELOG.md
+++ b/pi-evolve/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.3.2 (2026-08-19)
+
+### Fixed — Munin credential exfiltration guards (issue #18)
+
+- **cwd `.env*` trust gate:** `MUNIN_BASE_URL`/`MUNIN_API_KEY`/`MUNIN_PROJECT` from the project's `.env`/`.env.local` (including the parent-dir walk) are only read when the project is trusted (`ctx.isProjectTrusted()`). An untrusted checkout can no longer pair its `MUNIN_BASE_URL` with your shell-exported `MUNIN_API_KEY`. All store entrypoints (`activeBackend`, `writeLearning`, `readRecentLearnings`, `searchLearnings`) fail closed (untrusted) by default.
+- **Override needs its own key:** a `base_url` tool param without a matching `api_key` is ignored outright — never half-applied against the user's real key. Self-hosted servers keep working by passing `base_url` + `api_key` together.
+- **URL shape validation** (mirrors pi-munin's `normalizeBaseUrl`): http(s) only, no embedded credentials, no query/fragment, trailing slash normalized. Malformed URLs fall back to the local JSONL store instead of silently breaking persistence.
+- Replaces the earlier host-whitelist approach from this PR, which broke every self-hosted Munin deployment with a silent persistence failure and didn't check the URL scheme.
+
 ## 0.3.1 (2026-08-11)
 
 ### Fixed — per-turn input latency from uncached, unbounded Munin injection

--- a/pi-evolve/README.md
+++ b/pi-evolve/README.md
@@ -95,6 +95,14 @@ Optional `evolve` key in `settings.json`:
 - **Munin configured** (`MUNIN_API_KEY` + `MUNIN_PROJECT` set via env or `.env.local`) → learnings stored with tag `type:learning,domain:<inferred>`, searchable via `munin_search`.
 - **Munin not configured** → local JSONL at `.pi/evolve/learnings.jsonl` (capped at `localCap`).
 
+### Security (exfiltration guards, v0.3.2)
+
+Mirrors pi-munin's guards so a Munin credential can never be redirected:
+
+- `MUNIN_BASE_URL` from the project's `.env`/`.env.local` (including the parent-dir walk) is only read when the project is **trusted** — an untrusted checkout can't redirect your shell-exported `MUNIN_API_KEY` to an attacker's server. Global `~/.pi/agent/.env*` and real env vars are always honored.
+- A `base_url` passed alongside `api_key`/`project` tool params is accepted (self-hosted servers fine); `base_url` **without** its own `api_key` is ignored.
+- `MUNIN_BASE_URL` must be a well-formed http(s) URL without embedded credentials, query, or fragment.
+
 ## Safety
 
 - Input digests are **truncated to 200 chars and redacted** (API keys, tokens, Bearer headers, long base64 blobs → `[REDACTED]`) before reaching the buffer.

--- a/pi-evolve/extensions/index.ts
+++ b/pi-evolve/extensions/index.ts
@@ -127,7 +127,7 @@ export default function evolveExtension(pi: ExtensionAPI) {
             text: `Recent trajectory (${snapshot.length} entries, ${errors.length} errors, ${recoveries} recoveries):\n\n${digest}\n\n---\n${skeleton}`,
           },
         ],
-        details: { snapshot, store: activeBackend({}, resolveStoreConfig(settings), ctx.cwd) },
+        details: { snapshot, store: activeBackend({}, resolveStoreConfig(settings), ctx.cwd, ctx?.isProjectTrusted?.() === true) },
       };
     },
   });
@@ -188,14 +188,15 @@ export default function evolveExtension(pi: ExtensionAPI) {
       let stored: { key: string; title: string; storedAt: string };
       let backend: "munin" | "local";
       try {
-        stored = await writeLearning(learning, {}, storeCfg, ctx.cwd);
-        backend = activeBackend({}, storeCfg, ctx.cwd);
+        const trusted = ctx?.isProjectTrusted?.() === true;
+        stored = await writeLearning(learning, {}, storeCfg, ctx.cwd, trusted);
+        backend = activeBackend({}, storeCfg, ctx.cwd, trusted);
       } catch (err) {
         if (storeCfg.store === "auto") {
           // Fall back to local JSONL.
           try {
             const localCfg = { ...storeCfg, store: "local" as const };
-            stored = await writeLearning(learning, {}, localCfg, ctx.cwd);
+            stored = await writeLearning(learning, {}, localCfg, ctx.cwd, ctx?.isProjectTrusted?.() === true);
             backend = "local";
           } catch (localErr) {
             return {
@@ -241,7 +242,7 @@ export default function evolveExtension(pi: ExtensionAPI) {
     description: "Show pi-evolve status: buffer, last seal, learnings written, store backend.",
     handler: async (_args, ctx) => {
       const settings = readEvolveSettings(ctx.cwd);
-      const backend = activeBackend({}, resolveStoreConfig(settings), ctx.cwd);
+      const backend = activeBackend({}, resolveStoreConfig(settings), ctx.cwd, ctx?.isProjectTrusted?.() === true);
       const status = settings.enabled ? "enabled" : "disabled";
       const seal = lastSealTs ? new Date(lastSealTs).toISOString() : "never";
       ctx.ui.notify(
@@ -338,7 +339,7 @@ export default function evolveExtension(pi: ExtensionAPI) {
         const timeout = new Promise<Awaited<ReturnType<typeof searchLearnings>>>((resolve) => {
           timer = setTimeout(() => resolve([]), RECALL_TIMEOUT_MS);
         });
-        const found = await Promise.race([searchLearnings(text, 1, {}, storeCfg, ctx.cwd), timeout]);
+        const found = await Promise.race([searchLearnings(text, 1, {}, storeCfg, ctx.cwd, ctx?.isProjectTrusted?.() === true), timeout]);
         if (found.length > 0 && found[0]?.lesson) {
           // Sanitize like the injection path (inject.ts sanitize): single-line,
           // strip heading markers + code fences, so a stored lesson can't inject
@@ -436,7 +437,7 @@ export default function evolveExtension(pi: ExtensionAPI) {
           // best-effort context ("apply when its trigger matches") — the agent
           // rarely needs learnings before it has done any work — so the digest
           // simply lands in the cache for message 2 onward.
-          seedInFlight = seedInjectCache(cacheKey, settings, String(event?.prompt ?? ""), ctx.cwd)
+          seedInFlight = seedInjectCache(cacheKey, settings, String(event?.prompt ?? ""), ctx.cwd, ctx?.isProjectTrusted?.() === true)
             .catch(() => { /* best-effort */ })
             .finally(() => { seedInFlight = null; });
         }
@@ -480,6 +481,7 @@ async function seedInjectCache(
   settings: ReturnType<typeof readEvolveSettings>,
   promptText: string,
   cwd: string,
+  trusted = false,
 ): Promise<void> {
   const storeCfg = resolveStoreConfig(settings);
   const wantSimilar = settings.injectMode === "similar" || settings.injectMode === "both";
@@ -498,13 +500,13 @@ async function seedInjectCache(
   try {
     if (wantSimilar && promptText.trim()) {
       learnings = await Promise.race([
-        searchLearnings(promptText, settings.maxInject, {}, storeCfg, cwd),
+        searchLearnings(promptText, settings.maxInject, {}, storeCfg, cwd, trusted),
         deadline,
       ]);
     }
     if (learnings.length === 0 && (wantRecent || settings.injectMode === "similar")) {
       recentRan = true;
-      const recentPromise = readRecentLearnings(settings.maxInject, {}, storeCfg, cwd);
+      const recentPromise = readRecentLearnings(settings.maxInject, {}, storeCfg, cwd, trusted);
       if (searchTimedOut) {
         learnings = await raceWithBudget(recentPromise, RECENT_FALLBACK_BUDGET_MS, () => {
           recentTimedOut = true;

--- a/pi-evolve/extensions/lib/store.ts
+++ b/pi-evolve/extensions/lib/store.ts
@@ -49,57 +49,51 @@ interface MuninResolvedConfig {
   baseUrl: string;
 }
 
-// SECURITY: Allowed Munin base URLs to prevent open redirect attacks
-const ALLOWED_MUNIN_HOSTS = new Set([
-  "munin.kalera.ai",
-  "localhost",
-  "127.0.0.1",
-]);
-
-/**
- * Validate that a base_url points to an allowed host.
- * Prevents open redirect attacks where untrusted .env files redirect API keys.
- */
-function isAllowedBaseUrl(url: string): boolean {
+// SECURITY (mirrors pi-munin's guards — see issue #18):
+// 1. URL shape: http(s) only, no credentials, no query/fragment.
+// 2. An explicit base_url override requires an explicit api_key, so an
+//    attacker-controlled override can never pair with the user's real key.
+// 3. cwd/.env* (incl. the parent-dir walk) is only read for trusted projects,
+//    so an untrusted repo's .env can't redirect exfiltration either.
+function normalizeBaseUrl(value: string): string | null {
+  let url: URL;
   try {
-    const parsed = new URL(url);
-    // Allow localhost/127.0.0.1 for development
-    if (parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1") {
-      return true;
-    }
-    // Allow known Munin hosts
-    return ALLOWED_MUNIN_HOSTS.has(parsed.hostname);
+    url = new URL(value);
   } catch {
-    // Invalid URL — reject
-    return false;
+    return null;
   }
+  if (!["http:", "https:"].includes(url.protocol)) return null;
+  if (url.username || url.password) return null;
+  if (url.search || url.hash) return null;
+  return `${url.origin}${url.pathname.replace(/\/+$/, "")}`;
 }
 
 /** Try to resolve Munin config from env/dotfiles + tool params. Null when not configured. */
 export function tryResolveMunin(
   params: Record<string, unknown> = {},
   cwd = process.cwd(),
-  includeCwdEnv = true,
+  includeCwdEnv: boolean | (() => boolean) = false,
 ): MuninResolvedConfig | null {
-  const fileEnv = loadMuninEnv(cwd, includeCwdEnv);
-  const apiKey = (typeof params.api_key === "string" && params.api_key ? params.api_key : undefined)
+  // pi-munin's getMuninConfig mirrors this gate: cwd env files (and the
+  // parent-dir walk) are only read when the project is trusted.
+  const includeCwd = typeof includeCwdEnv === "function" ? includeCwdEnv() : includeCwdEnv;
+  const fileEnv = loadMuninEnv(cwd, includeCwd);
+  const explicitApiKey = typeof params.api_key === "string" && params.api_key ? params.api_key : undefined;
+  const explicitBaseUrl = typeof params.base_url === "string" && params.base_url ? params.base_url : undefined;
+  // SECURITY: a base_url override without its own api_key is ignored outright —
+  // an attacker-controlled override must never pair with the user's real key.
+  if (explicitBaseUrl && !explicitApiKey) return null;
+  const apiKey = explicitApiKey
     || process.env.MUNIN_API_KEY
     || fileEnv.MUNIN_API_KEY;
   const projectId = (typeof params.project === "string" && params.project ? params.project : undefined)
     || process.env.MUNIN_PROJECT
     || fileEnv.MUNIN_PROJECT;
   if (!apiKey || !projectId) return null;
-  let baseUrl = (typeof params.base_url === "string" && params.base_url ? params.base_url : undefined)
-    || process.env.MUNIN_BASE_URL
-    || fileEnv.MUNIN_BASE_URL
-    || "https://munin.kalera.ai";
-  // Normalize: strip trailing slash.
-  baseUrl = baseUrl.replace(/\/+$/, "");
-  // SECURITY: Validate base_url to prevent open redirect attacks
-  if (!isAllowedBaseUrl(baseUrl)) {
-    console.warn(`[pi-evolve] SECURITY: Rejected untrusted base_url: ${baseUrl}`);
-    return null;
-  }
+  const baseUrl = normalizeBaseUrl(
+    explicitBaseUrl || process.env.MUNIN_BASE_URL || fileEnv.MUNIN_BASE_URL || "https://munin.kalera.ai",
+  );
+  if (!baseUrl) return null; // malformed URL shape — fall back to the local store
   return { apiKey, projectId, baseUrl };
 }
 
@@ -150,8 +144,8 @@ function parentEnvCandidates(cwd: string): string[] {
 // ---------------------------------------------------------------------------
 
 /** Decide the active backend given resolved config + user preference. */
-export function activeBackend(params: Record<string, unknown>, cfg: StoreConfig, cwd: string): "munin" | "local" {
-  const munin = tryResolveMunin(params, cwd, true);
+export function activeBackend(params: Record<string, unknown>, cfg: StoreConfig, cwd: string, trusted?: boolean): "munin" | "local" {
+  const munin = tryResolveMunin(params, cwd, trusted === true);
   if (cfg.store === "local") return "local";
   if (cfg.store === "munin") return munin ? "munin" : "local";
   return munin ? "munin" : "local"; // auto
@@ -163,6 +157,7 @@ export async function writeLearning(
   params: Record<string, unknown>,
   cfg: StoreConfig,
   cwd: string,
+  trusted?: boolean,
 ): Promise<StoredLearning> {
   const key = makeKey(learning);
   const title = `[${learning.kind}] ${learning.trigger}`.slice(0, 120);
@@ -175,7 +170,7 @@ export async function writeLearning(
 
   const backend = activeBackend(params, cfg, cwd);
   if (backend === "munin") {
-    const munin = tryResolveMunin(params, cwd, true)!;
+    const munin = tryResolveMunin(params, cwd, trusted === true)!;
     const client = new MuninClient({ apiKey: munin.apiKey, baseUrl: munin.baseUrl });
     // ponytail: direct store() — no capability dance; if it throws, caller handles.
     if (typeof (client as any).store === "function") {
@@ -204,10 +199,11 @@ export async function readRecentLearnings(
   params: Record<string, unknown>,
   cfg: StoreConfig,
   cwd: string,
+  trusted?: boolean,
 ): Promise<StoredLearning[]> {
   const backend = activeBackend(params, cfg, cwd);
   if (backend === "munin") {
-    const munin = tryResolveMunin(params, cwd, true)!;
+    const munin = tryResolveMunin(params, cwd, trusted === true)!;
     const client = new MuninClient({ apiKey: munin.apiKey, baseUrl: munin.baseUrl });
     let result: unknown;
     try {
@@ -238,10 +234,11 @@ export async function searchLearnings(
   params: Record<string, unknown>,
   cfg: StoreConfig,
   cwd: string,
+  trusted?: boolean,
 ): Promise<StoredLearning[]> {
   const backend = activeBackend(params, cfg, cwd);
   if (backend === "munin") {
-    const munin = tryResolveMunin(params, cwd, true)!;
+    const munin = tryResolveMunin(params, cwd, trusted === true)!;
     const client = new MuninClient({ apiKey: munin.apiKey, baseUrl: munin.baseUrl });
     let result: unknown;
     try {

--- a/pi-evolve/extensions/lib/store.ts
+++ b/pi-evolve/extensions/lib/store.ts
@@ -49,6 +49,32 @@ interface MuninResolvedConfig {
   baseUrl: string;
 }
 
+// SECURITY: Allowed Munin base URLs to prevent open redirect attacks
+const ALLOWED_MUNIN_HOSTS = new Set([
+  "munin.kalera.ai",
+  "localhost",
+  "127.0.0.1",
+]);
+
+/**
+ * Validate that a base_url points to an allowed host.
+ * Prevents open redirect attacks where untrusted .env files redirect API keys.
+ */
+function isAllowedBaseUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    // Allow localhost/127.0.0.1 for development
+    if (parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1") {
+      return true;
+    }
+    // Allow known Munin hosts
+    return ALLOWED_MUNIN_HOSTS.has(parsed.hostname);
+  } catch {
+    // Invalid URL — reject
+    return false;
+  }
+}
+
 /** Try to resolve Munin config from env/dotfiles + tool params. Null when not configured. */
 export function tryResolveMunin(
   params: Record<string, unknown> = {},
@@ -69,6 +95,11 @@ export function tryResolveMunin(
     || "https://munin.kalera.ai";
   // Normalize: strip trailing slash.
   baseUrl = baseUrl.replace(/\/+$/, "");
+  // SECURITY: Validate base_url to prevent open redirect attacks
+  if (!isAllowedBaseUrl(baseUrl)) {
+    console.warn(`[pi-evolve] SECURITY: Rejected untrusted base_url: ${baseUrl}`);
+    return null;
+  }
   return { apiKey, projectId, baseUrl };
 }
 

--- a/pi-evolve/extensions/test/store.test.ts
+++ b/pi-evolve/extensions/test/store.test.ts
@@ -4,6 +4,7 @@ import { join, dirname } from "node:path";
 import { expect } from "chai";
 import { MuninClient } from "@kalera/munin-sdk";
 import {
+  tryResolveMunin,
   type Learning,
   resolveStoreConfig,
   activeBackend,
@@ -70,6 +71,59 @@ describe("store config", () => {
       restoreEnv(saved);
       rmSync(cwd, { recursive: true, force: true });
     }
+  });
+});
+
+describe("Munin exfiltration guards (issue #18)", () => {
+  let cwd: string;
+  let saved: Record<string, string | undefined>;
+  beforeEach(() => {
+    cwd = tmpCwd();
+    saved = saveEnv();
+  });
+  afterEach(() => {
+    restoreEnv(saved);
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it("ignores base_url override without explicit api_key (never pairs with user's key)", () => {
+    process.env.MUNIN_API_KEY = "real-user-key";
+    process.env.MUNIN_PROJECT = "proj";
+    const munin = tryResolveMunin({ base_url: "https://attacker.example" }, cwd);
+    expect(munin).to.equal(null);
+  });
+
+  it("accepts base_url override WITH its own api_key", () => {
+    const munin = tryResolveMunin({ base_url: "https://selfhosted.example/", api_key: "k", project: "p" }, cwd);
+    expect(munin).to.not.equal(null);
+    expect(munin!.baseUrl).to.equal("https://selfhosted.example"); // trailing slash stripped
+  });
+
+  it("rejects non-http(s) schemes, embedded credentials, and query/fragment", () => {
+    process.env.MUNIN_API_KEY = "k";
+    process.env.MUNIN_PROJECT = "p";
+    expect(tryResolveMunin({ base_url: "file://munin.kalera.ai/x", api_key: "k", project: "p" }, cwd)).to.equal(null);
+    expect(tryResolveMunin({ base_url: "https://user:pass@munin.example", api_key: "k", project: "p" }, cwd)).to.equal(null);
+    expect(tryResolveMunin({ base_url: "https://munin.example/?q=1", api_key: "k", project: "p" }, cwd)).to.equal(null);
+    expect(tryResolveMunin({ base_url: "not a url", api_key: "k", project: "p" }, cwd)).to.equal(null);
+  });
+
+  it("does NOT read cwd .env when project is untrusted (fail closed)", () => {
+    process.env.MUNIN_API_KEY = "real-user-key"; // shell env — attacker needs only a base_url redirect
+    process.env.MUNIN_PROJECT = "p";
+    writeFileSync(join(cwd, ".env"), "MUNIN_BASE_URL=https://attacker.example\n");
+    // untrusted (default): cwd .env ignored → default baseUrl, not attacker's
+    expect(tryResolveMunin({}, cwd, false)!.baseUrl).to.equal("https://munin.kalera.ai");
+    // trusted: cwd .env is honored
+    expect(tryResolveMunin({}, cwd, true)!.baseUrl).to.equal("https://attacker.example");
+  });
+
+  it("defaults to untrusted: cwd .env not read when trusted flag is omitted", () => {
+    process.env.MUNIN_API_KEY = "k";
+    process.env.MUNIN_PROJECT = "p";
+    writeFileSync(join(cwd, ".env"), "MUNIN_BASE_URL=https://attacker.example\n");
+    expect(tryResolveMunin({}, cwd)!.baseUrl).to.equal("https://munin.kalera.ai");
+    expect(activeBackend({}, resolveStoreConfig({ store: "auto" }), cwd)).to.equal("munin"); // still works via shell env
   });
 });
 

--- a/pi-evolve/package.json
+++ b/pi-evolve/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bacnh85/pi-evolve",
-  "version": "0.3.1",
-  "description": "Pi extension that adds a trajectory-based self-learning loop — automatic capture, reflection, and contextual injection of learnings.",
+  "version": "0.3.2",
+  "description": "Pi extension that adds a trajectory-based self-learning loop \u2014 automatic capture, reflection, and contextual injection of learnings.",
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Fixes #18

## Changes
- Added ALLOWED_MUNIN_HOSTS whitelist (munin.kalera.ai, localhost, 127.0.0.1)
- Added isAllowedBaseUrl() function with URL validation
- Added validation in tryResolveMunin() before returning config
- Logs warning and returns null for untrusted base_urls

## Security Impact
Prevents untrusted .env files from redirecting API keys to malicious servers via open redirect attacks.