### PR TITLE
pi-agy: update flash aliases to gemini-3.7-flash

### DIFF
--- a/pi-agy/CHANGELOG.md
+++ b/pi-agy/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.3.2 (2026-08-19)
+
+### Changed
+
+- Flash aliases (`flash-low/medium/high`, legacy `flash`/`flash-lo`) now map to
+  `gemini-3.7-flash-*` — the current Flash generation in agy 1.1.x. `pro-*`,
+  `sonnet`, `opus`, and `gpt-oss` are unchanged. Verified against live
+  `agy models` on agy CLI 1.1.14.
+
 ## 0.3.1 (2026-08-05)
 
 ### Improvements

--- a/pi-agy/README.md
+++ b/pi-agy/README.md
@@ -57,9 +57,9 @@ Aliases map to agy's canonical machine names (run `agy models` to list them):
 
 | Alias | agy machine name | Typical use |
 |-------|------------------|-------------|
-| `flash-low` | `gemini-3.6-flash-low` | Trivial, few-step, high-volume work |
-| `flash-medium` | `gemini-3.6-flash-medium` | Default coding, exploration, and tests |
-| `flash-high` | `gemini-3.6-flash-high` | Difficult agentic work |
+| `flash-low` | `gemini-3.7-flash-low` | Trivial, few-step, high-volume work |
+| `flash-medium` | `gemini-3.7-flash-medium` | Default coding, exploration, and tests |
+| `flash-high` | `gemini-3.7-flash-high` | Difficult agentic work |
 | `pro-low` | `gemini-3.1-pro-low` | Advanced reasoning |
 | `pro-high` | `gemini-3.1-pro-high` | Hardest Gemini reasoning |
 | `sonnet` | `claude-sonnet-4-6` | Normal Claude coding and review |

--- a/pi-agy/extensions/lib/cli.ts
+++ b/pi-agy/extensions/lib/cli.ts
@@ -38,9 +38,9 @@ const PREFLIGHT_TIMEOUT_MS = 10_000;
 const MAX_CAPTURE_BYTES = 64 * 1024;
 
 const MODEL_MAP: Record<AgyModel, string> = {
-  "flash-low": "gemini-3.6-flash-low",
-  "flash-medium": "gemini-3.6-flash-medium",
-  "flash-high": "gemini-3.6-flash-high",
+  "flash-low": "gemini-3.7-flash-low",
+  "flash-medium": "gemini-3.7-flash-medium",
+  "flash-high": "gemini-3.7-flash-high",
   "pro-low": "gemini-3.1-pro-low",
   "pro-high": "gemini-3.1-pro-high",
   sonnet: "claude-sonnet-4-6",

--- a/pi-agy/extensions/test/cli.test.ts
+++ b/pi-agy/extensions/test/cli.test.ts
@@ -37,9 +37,9 @@ describe("buildAgyArgs", () => {
   });
 
   const models = [
-    ["flash-low", "gemini-3.6-flash-low"],
-    ["flash-medium", "gemini-3.6-flash-medium"],
-    ["flash-high", "gemini-3.6-flash-high"],
+    ["flash-low", "gemini-3.7-flash-low"],
+    ["flash-medium", "gemini-3.7-flash-medium"],
+    ["flash-high", "gemini-3.7-flash-high"],
     ["pro-low", "gemini-3.1-pro-low"],
     ["pro-high", "gemini-3.1-pro-high"],
     ["sonnet", "claude-sonnet-4-6"],
@@ -55,8 +55,8 @@ describe("buildAgyArgs", () => {
   }
 
   for (const [tier, displayName] of [
-    ["flash", "gemini-3.6-flash-high"],
-    ["flash-lo", "gemini-3.6-flash-low"],
+    ["flash", "gemini-3.7-flash-high"],
+    ["flash-lo", "gemini-3.7-flash-low"],
     ["pro", "gemini-3.1-pro-high"],
   ] as const) {
     it(`keeps legacy tier: ${tier}`, () => {
@@ -72,7 +72,7 @@ describe("buildAgyArgs", () => {
 
   it("defaults to flash-medium when model and tier are omitted", () => {
     const args = buildAgyArgs({ prompt: "test", dir: "/tmp", timeout_ms: 60_000 });
-    expect(args[args.indexOf("--model") + 1]).to.equal("gemini-3.6-flash-medium");
+    expect(args[args.indexOf("--model") + 1]).to.equal("gemini-3.7-flash-medium");
   });
 
   it("calculates --print-timeout from timeout_ms (rounded up)", () => {
@@ -90,7 +90,7 @@ describe("buildAgyArgs", () => {
   it("builds args in correct order: model, print-timeout, add-dir, mode, skip-perm, -p, prompt", () => {
     const args = buildAgyArgs({ prompt: "go", dir: "/x", timeout_ms: 30_000 });
     expect(args).to.deep.equal([
-      "--model", "gemini-3.6-flash-medium",
+      "--model", "gemini-3.7-flash-medium",
       "--print-timeout", "30s",
       "--add-dir", "/x",
       "--mode", "accept-edits",

--- a/pi-agy/extensions/test/integration.test.ts
+++ b/pi-agy/extensions/test/integration.test.ts
@@ -220,9 +220,9 @@ const LIVE = process.env.AGY_LIVE === "1";
   this.timeout(180_000);
   const { execFileSync } = _require("node:child_process");
   const aliases: Record<string, string> = {
-    "flash-low": "gemini-3.6-flash-low",
-    "flash-medium": "gemini-3.6-flash-medium",
-    "flash-high": "gemini-3.6-flash-high",
+    "flash-low": "gemini-3.7-flash-low",
+    "flash-medium": "gemini-3.7-flash-medium",
+    "flash-high": "gemini-3.7-flash-high",
     "pro-low": "gemini-3.1-pro-low",
     "pro-high": "gemini-3.1-pro-high",
     sonnet: "claude-sonnet-4-6",

--- a/pi-agy/package-lock.json
+++ b/pi-agy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bacnh85/pi-agy",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bacnh85/pi-agy",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/typebox": "^0.34.41",

--- a/pi-agy/package.json
+++ b/pi-agy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bacnh85/pi-agy",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Google Antigravity CLI (agy) bridge for Pi — delegate bulk scaffolding, refactors, and test generation to a leaner model.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

agy CLI 1.1.x exposes **gemini-3.7-flash-{low,medium,high}** as the current Flash generation:

```
$ agy models
gemini-3.7-flash-high	Gemini 3.7 Flash (High)
gemini-3.7-flash-medium	Gemini 3.7 Flash (Medium)
gemini-3.7-flash-low	Gemini 3.7 Flash (Low)
gemini-3.6-flash-high	Gemini 3.6 Flash (High)
...
```

This updates the three `flash-*` aliases in `MODEL_MAP` (plus tests and README table) from 3.6 to 3.7. `pro-low`/`pro-high` (gemini-3.1-pro-*) and the Claude/GPT-OSS aliases are unchanged and still valid.

## Test plan

- [x] `npm test` — 56 passing
- [x] Verified live: delegated a task through pi → `agy_execute` (flash-low) → `gemini-3.7-flash-low` responds correctly