### PR TITLE
pi-web: bump agy extraction default to gemini-3.7-flash-medium

### DIFF
--- a/pi-web/CHANGELOG.md
+++ b/pi-web/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.1 (2026-08-19)
+
+### Changed
+
+- `web_extract` agy backend default model updated to `gemini-3.7-flash-medium`
+  — the current Flash generation in agy 1.1.x (3.6 is still served, this just
+  follows the latest).
+
 ## 0.6.0 (2026-08-07)
 
 ### Features

--- a/pi-web/extensions/lib/agy.ts
+++ b/pi-web/extensions/lib/agy.ts
@@ -17,7 +17,7 @@ const cp = _require("node:child_process") as typeof import("node:child_process")
 const AGY_FETCH_TIMEOUT_MS = 90_000; // agy needs time for model call + web fetch
 const AGY_PROBE_TIMEOUT_MS = 5_000;
 const AGY_MAX_OUTPUT_BYTES = 200_000; // bound output to protect Pi context
-export const AGY_MODEL = "gemini-3.6-flash-medium"; // ponytail: fixed default; users needing model control use agy_execute
+export const AGY_MODEL = "gemini-3.7-flash-medium"; // ponytail: fixed default; users needing model control use agy_execute
 
 // Cache install status with a TTL — spawnSync blocks the event loop up to
 // AGY_PROBE_TIMEOUT_MS, and web_status/extract can call this repeatedly.

--- a/pi-web/package-lock.json
+++ b/pi-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bacnh85/pi-web",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bacnh85/pi-web",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",


### PR DESCRIPTION
One-line follow-up to #23, as suggested in review: `pi-web/extensions/lib/agy.ts` pinned `AGY_MODEL = "gemini-3.6-flash-medium"` for the `web_extract` agy backend. Bumps it to the current Flash generation.

3.6 is still served, so this is cosmetic-consistency only; no behavior risk.

## Release bookkeeping

- `pi-web/package.json` 0.6.0 → 0.6.1 (lockfile versions synced, surgical 2-line change)
- CHANGELOG entry for 0.6.1

## Test plan

- [x] `npm test` — 127 passing