### PR TITLE
fix(pi-a2a): fire extension session lifecycle in inbound child sessions (MCP tools for dispatched agents)

### DIFF
--- a/pi-a2a/README.md
+++ b/pi-a2a/README.md
@@ -418,6 +418,14 @@ The isolated session's activity is **surfaced to the host TUI** as transcript
 messages + toasts (see "Inbound activity in the host TUI") — you see what the
 inbound task is doing without it running in your live session.
 
+The isolated session runs the **full extension lifecycle**: after creation it
+fires `session_start` (via `bindExtensions`, the same thing the SDK's print
+mode does), so extensions that wire their tools on session start — e.g.
+pi-mcp-extension's MCP servers — are available to the dispatched agent, and
+`session_shutdown` is emitted on completion so extension-started processes
+are cleaned up. The child never touches the host's own inbound server:
+server lifecycle handlers are host-session-only.
+
 ## Hermes interop
 
 The primary interop target. Hermes (`~/.hermes/hermes-agent`, A2A platform

--- a/pi-a2a/extensions/index.ts
+++ b/pi-a2a/extensions/index.ts
@@ -93,6 +93,20 @@ function makeSessionRunner(ctx: ExtensionContext): SessionRunner {
         : {}),
     } as any);
     const session = created.session;
+    // Fire the extension session lifecycle for the child. createAgentSession
+    // loads extension packages but never emits session_start — the SDK's own
+    // print/rpc modes emit it via bindExtensions() right after creation — so
+    // without this the child runs every extension's factory but none of their
+    // session_start handlers: extensions that register tools there (e.g.
+    // pi-mcp-extension, which wires ALL of its MCP servers/tools on
+    // session_start) are silently missing from dispatched sessions. mode
+    // "print" with no uiContext keeps ctx.hasUI === false, matching how the
+    // host-only session_start guard below classifies child sessions.
+    try {
+      await session.bindExtensions({ mode: "print" });
+    } catch {
+      // Best-effort: a child that fails to bind still runs base tools.
+    }
     let reply = "";
     let inputRequired = false;
     let resolveDone!: () => void;
@@ -133,6 +147,16 @@ function makeSessionRunner(ctx: ExtensionContext): SessionRunner {
     } finally {
       signal.removeEventListener("abort", onAbort);
       unsub();
+      // dispose() does NOT emit session_shutdown (it only invalidates the
+      // extension runner), so emit it explicitly first: extensions that
+      // started processes on session_start (pi-mcp-extension's stdio MCP
+      // servers) stop them on session_shutdown and would otherwise leak one
+      // process per inbound task.
+      try {
+        await session.extensionRunner?.emit({ type: "session_shutdown", reason: "quit" });
+      } catch {
+        /* best-effort */
+      }
       try {
         session.dispose();
       } catch {
@@ -925,7 +949,15 @@ export default function a2aExtension(pi: ExtensionAPI): void {
     }
   });
 
-  pi.on("session_shutdown", async () => {
+  pi.on("session_shutdown", async (_event, ctx) => {
+    // Only the HOST session owns the inbound server. Child sessions share
+    // this cached extension factory (the loader caches it per process), so
+    // the session_shutdown makeSessionRunner now emits for each child would
+    // otherwise stop the host's shared `server` mid-dispatch. Same host-only
+    // classification as session_start above: children have hasUI=false and
+    // mode "print"; json-mode hosts are long-lived HOSTS, not children —
+    // they keep the shutdown.
+    if (!ctx.hasUI && ctx.mode !== "json") return;
     if (server) {
       try {
         await server.stop();


### PR DESCRIPTION
## Problem

An inbound A2A task spawns an isolated child session (`createAgentSession` in `makeSessionRunner`). The SDK **never emits `session_start` for SDK-created sessions** — the only emitter is `session.bindExtensions()`, which the SDK's own print/rpc modes call right after creation. So a dispatched child:

- ran every extension's *factory* but **none of their `session_start` handlers** — extensions that register tools there (e.g. `pi-mcp-extension`, which wires **all** of its MCP servers/tools on `session_start`) were silently missing from dispatched agents, which ran with base tools only;
- never received `session_shutdown` — `dispose()` does not emit it, so extension-started processes (stdio MCP servers) would **leak one process per inbound task** once extensions do run.

## Fix — three changes

1. **`makeSessionRunner`: `await session.bindExtensions({ mode: "print" })`** after `createAgentSession` (best-effort). Fires `session_start` for the child; `_refreshToolRegistry()` then auto-activates newly registered tools. `mode: "print"` with no `uiContext` keeps `ctx.hasUI === false` — exactly how the existing host-only `session_start` guard below classifies children, so children still never auto-start their own inbound server.
2. **Emit `session_shutdown` (reason `"quit"`) before `dispose()`** in the runner's finally block, so extensions that started processes on `session_start` stop them per task instead of leaking.
3. **Host-only guard on this extension's own `session_shutdown` handler** — the same `if (!ctx.hasUI && ctx.mode !== "json") return;` classification as its `session_start` handler. This is load-bearing: the extension factory is cached per process and shared host↔children, and the module-level `server` is the *host's* inbound server — without the guard, the first child's shutdown would `server.stop()` the host mid-dispatch.

## Verification

Live end-to-end (pi-coding-agent 0.84.4, macOS, loopback A2A host in `--mode rpc`):

- **Child gets the MCP surface:** dispatched `message/send` asking the child to read a record via `mcp_knowfleet_task_read` → the child called the tool directly (its own stdio MCP process spawned on `session_start`) and returned the real payload.
- **No process leak:** knowfleet MCP process count 11 baseline → +1 for the host's own eager server only; the child's MCP process stopped on its `session_shutdown` (11 → 12 → 11 across host start/kill, zero leaks per dispatch).
- **Host survives child shutdown:** a second dispatch to the same host succeeded — without edit 3 the shared inbound server would have been stopped by the first child's shutdown.
- `tsc --noEmit` clean; the 309-test mocha suite passes unchanged.

## Related

`pi-subagent`'s runner (`extensions/runner.ts`) has the same latent gap — its child sessions never get `bindExtensions()`, so extension tools wired on `session_start` are missing there too. Same one-line treatment would apply; left out of this PR to keep it scoped to pi-a2a.