### PR TITLE
fix(pi-a2a): report context-clamped dispatch deaths as FAILED, not COMPLETED

### DIFF
--- a/pi-a2a/README.md
+++ b/pi-a2a/README.md
@@ -426,6 +426,15 @@ pi-mcp-extension's MCP servers — are available to the dispatched agent, and
 are cleaned up. The child never touches the host's own inbound server:
 server lifecycle handlers are host-session-only.
 
+Long dispatches run with **auto-compaction enabled** and a keep window scaled
+to the model's context window, and the runner waits for the session's
+post-run recovery before reporting completion. Without that, a task that
+grows near the context window dies misleadingly: pi clamps `max_tokens` to
+what remains (down to 1), the model's final turn ends on a length stop with
+no text, and the task would otherwise complete with the *previous* turn's
+stale reply. Such a turn now fails the task (`FAILED`, status message
+"no usable reply was produced") instead of masquerading as success.
+
 ## Hermes interop
 
 The primary interop target. Hermes (`~/.hermes/hermes-agent`, A2A platform

--- a/pi-a2a/extensions/index.ts
+++ b/pi-a2a/extensions/index.ts
@@ -60,8 +60,23 @@ function makeSessionRunner(ctx: ExtensionContext): SessionRunner {
     const model = ctx.model;
     if (!model) throw new Error("no active model on the host session");
     const cwd = ctx.cwd || process.cwd();
+    // Auto-compaction is the only recovery path a long dispatch has near
+    // the context window: pi clamps max_tokens to the remaining budget
+    // (down to 1 at the extreme), so without compact-and-retry the final
+    // turn is cut and the task dies with a truncated or empty reply. The
+    // keep window is scaled to the model's context window (stock: flat
+    // 20k) because pi's cut-point walk never cuts at tool results — a
+    // single tool-result batch bigger than the keep budget strands the
+    // walk and auto-compaction silently no-ops exactly when it is most
+    // needed. Dispatched coding tasks routinely produce such batches (one
+    // large read or command dump), so the keep budget needs headroom
+    // proportional to the window.
+    const keepRecentTokens = Math.max(
+      20_000,
+      Math.floor((model.contextWindow ?? 128_000) / 5),
+    );
     const settingsManager = SettingsManager.inMemory({
-      compaction: { enabled: false },
+      compaction: { enabled: true, keepRecentTokens },
       retry: { enabled: true, maxRetries: 1 },
     });
     // The loader must NOT receive the inMemory settingsManager: it would then
@@ -109,6 +124,10 @@ function makeSessionRunner(ctx: ExtensionContext): SessionRunner {
     }
     let reply = "";
     let inputRequired = false;
+    // Stop reason of the LAST assistant message and whether it carried any
+    // text — consumed by the stunted-reply check after the run completes.
+    let terminalStopReason: string | undefined;
+    let terminalHadText = false;
     let resolveDone!: () => void;
     const done = new Promise<void>((r) => (resolveDone = r));
     const unsub = session.subscribe((event: any) => {
@@ -126,15 +145,19 @@ function makeSessionRunner(ctx: ExtensionContext): SessionRunner {
           .map((p: any) => (typeof p?.text === "string" ? p.text : ""))
           .join("");
         if (text) reply = text;
+        terminalStopReason = event.message?.stopReason;
+        terminalHadText = Boolean(text);
         if (/\[INPUT_REQUIRED\]/i.test(reply)) {
           inputRequired = true;
           reply = reply.replace(/\[INPUT_REQUIRED\]\s*/gi, "").trim();
         }
-      } else if (event.type === "agent_end" && !event.willRetry) {
-        resolveDone();
       }
     });
     const onAbort = () => {
+      // Settle the race (see the prompt race below) so a prompt() that
+      // outlives session.abort() cannot hang the runner past the server's
+      // reply window.
+      resolveDone();
       try {
         session.abort();
       } catch {
@@ -143,6 +166,16 @@ function makeSessionRunner(ctx: ExtensionContext): SessionRunner {
     };
     signal.addEventListener("abort", onAbort, { once: true });
     try {
+      // Settle the race on prompt() completion, not on agent_end: agent_end
+      // fires when the model turn ends — BEFORE the post-run overflow
+      // recovery that prompt() awaits (agent-session's _handlePostAgentRun
+      // → compact-and-retry). Settling at agent_end let the cleanup below
+      // dispose() the session while that recovery compaction was still in
+      // flight (dispose → abortCompaction), so a context-clamped turn could
+      // never recover even though pi's compact-and-retry would have saved
+      // it. prompt() resolves only after recovery and any continuation
+      // turns finish; aborts still settle the race immediately via onAbort
+      // above.
       await Promise.race([session.prompt(message), done]);
     } finally {
       signal.removeEventListener("abort", onAbort);
@@ -162,6 +195,17 @@ function makeSessionRunner(ctx: ExtensionContext): SessionRunner {
       } catch {
         /* ignore */
       }
+    }
+    if (terminalStopReason === "length" && !terminalHadText) {
+      // A length stop with no assistant text means the provider capped
+      // output before any usable content — typically max_tokens clamped
+      // against the context estimate. `reply` still holds the PREVIOUS
+      // turn's text, so returning normally would report the task COMPLETED
+      // with a stale mid-work answer. Throw so the task maps to FAILED —
+      // a dispatcher must not mistake this for a finished worker.
+      throw new Error(
+        "run ended on a length stop with no assistant text — no usable reply was produced (output capped before any content; context-clamped max_tokens?)",
+      );
     }
     return { reply: reply || "(no reply)", inputRequired };
   };

--- a/pi-a2a/extensions/lib/server.ts
+++ b/pi-a2a/extensions/lib/server.ts
@@ -167,6 +167,13 @@ class RateLimiter {
 // Session runner — the injectable boundary for testing
 // ---------------------------------------------------------------------------
 
+/**
+ * Contract: a normal return asserts the turn finished (or needs input) —
+ * in particular, that the final assistant message carried usable text. A
+ * turn that ends on a length stop with no assistant text produced no usable
+ * reply and MUST throw, so messageSend maps the task to FAILED instead of
+ * completing it with the previous turn's stale text.
+ */
 export interface SessionRunner {
   (opts: {
     message: string;

--- a/pi-a2a/extensions/test/server.test.ts
+++ b/pi-a2a/extensions/test/server.test.ts
@@ -961,6 +961,57 @@ describe("server", () => {
     });
   });
 
+  describe("stunted length-stop reply is not COMPLETED", () => {
+    // A context-clamped turn ends with stopReason "length" and no assistant
+    // text (max_tokens squeezed to the remaining context, the model emits
+    // almost nothing). The session runner now throws for such a turn — the
+    // alternative is returning the PREVIOUS turn's text normally, which
+    // takes messageSend's success path: the task completes with a stale
+    // mid-work reply and a dispatcher cannot tell a dead worker from a
+    // finished one. These tests lock the classification the contract
+    // depends on: the throw maps to FAILED with a status message and no
+    // reply artifact.
+    const stuntedRunner: SessionRunner = async () => {
+      throw new Error(
+        "run ended on a length stop with no assistant text — no usable reply was produced (output capped before any content; context-clamped max_tokens?)",
+      );
+    };
+
+    it("maps a length-stop-no-text turn to STATE_FAILED with a status message", async () => {
+      const events: any[] = [];
+      const { url, stop } = await startServer({ cfg: DEFAULTS(), runner: stuntedRunner, onActivity: (a) => events.push(a) });
+      try {
+        const r = await jsonRpc(url, "SendMessage", {
+          message: { role: "ROLE_USER", parts: [{ text: "long task" }] },
+        });
+        assert.equal(r.result.status.state, STATE_FAILED);
+        const msgText = r.result.status.message?.parts?.[0]?.text ?? "";
+        assert.include(msgText, "no usable reply", "status message explains the stunted turn");
+        assert.isUndefined(r.result.artifacts, "a stunted turn carries no reply artifact");
+        // The host toast must say failed — not "completed (Ns)".
+        assert.deepEqual(events.map((e) => e.type), ["arrived", "failed"]);
+      } finally {
+        await stop();
+      }
+    });
+
+    it("does not count the stunted turn as completed in metrics", async () => {
+      const before = metrics.tasksCompleted;
+      const beforeFailed = metrics.tasksFailed;
+      const { url, stop } = await startServer({ cfg: DEFAULTS(), runner: stuntedRunner });
+      try {
+        const r = await jsonRpc(url, "SendMessage", {
+          message: { role: "ROLE_USER", parts: [{ text: "long task" }] },
+        });
+        assert.equal(r.result.status.state, STATE_FAILED);
+        assert.equal(metrics.tasksCompleted, before, "stunted turns never increment completions");
+        assert.equal(metrics.tasksFailed, beforeFailed + 1, "stunted turns increment failures");
+      } finally {
+        await stop();
+      }
+    });
+  });
+
   describe("port fallback (EADDRINUSE → next port)", () => {
     /** Pre-bind the configured port so the A2A server must fall back. */
     async function holdPort(port: number): Promise<() => Promise<void>> {


### PR DESCRIPTION
A dispatched A2A task that grows near the model's context window dies **misleadingly**: the runner completes the task with the *previous* turn's reply while the worker is actually dead.

## The failure chain

1. Session context grows across a long dispatch (normal for coding work — many tool results).
2. pi clamps `max_tokens` to the remaining window; at the extreme it sends `max_tokens: 1`.
3. The model's final turn ends with `stopReason: "length"` and **no text** (a single token of thinking, nothing usable). The agent loop ends "normally".
4. The runner's `reply` still holds the **previous** turn's text, so it returns normally → `messageSend` takes the success path → `TASK_STATE_COMPLETED` with a stale mid-work reply.

We lost a dispatched worker exactly this way: a six-task batch ran ~34 minutes, its final turn's tool results pushed the context estimate past the compaction threshold, and the task came back COMPLETED with a mid-work narration while every remaining write was silently dropped.

## Why auto-compaction didn't save it — three layers

- **The runner disabled compaction for child sessions** (`compaction: { enabled: false }`) — issue #29. There is no compact-and-retry at all, so step 2 is unrecoverable. #29 was closed as fixed with #28, but that commit doesn't touch this setting — `main` still passes `enabled: false` — so this PR includes the flip.
- **Even with compaction on, the stock keep window is defeat-able by one tool batch**: pi's cut-point walk never cuts at tool results, so when a single batch's results exceed `keepRecentTokens` (stock 20k), the walk finds no cut point at-or-after the budget crossing and auto-compaction **silently no-ops** — exactly when it is most needed (reported upstream as earendil-works/pi#7201 and #8498, both closed without action; the behavior is still present in pi core). One large read or command dump routinely exceeds 20k estimated tokens.
- **The done-race aborted the recovery**: the runner settled its `prompt()`-vs-done race on `agent_end`, which fires *before* the post-run overflow recovery that `prompt()` awaits. Cleanup then `dispose()`d the session mid-recovery (`dispose → abortCompaction`), so even a session that *would* have compacted-and-retried never got the chance.

## Changes (all in `makeSessionRunner`)

1. **Compaction on, keep window scaled to the model's context window** — `max(20_000, contextWindow / 5)`: the recovery path exists, and ordinary large tool batches can't strand the cut-point walk. This is a mitigation, not a fix — the real fix is a split-turn fallback in pi core's `findCutPoint`.
2. **The done-race settles on `prompt()` completion** instead of `agent_end`, so cleanup cannot abort an in-flight recovery compaction. Aborts still settle immediately via the abort listener, so a hung `prompt()` cannot outlive the reply window.
3. **A turn that ends on a length stop with no assistant text throws**, so `messageSend` maps the task to `FAILED` with a status message ("no usable reply was produced…") instead of completing it with the stale reply.

## Tests

Two new regression tests lock the classification: a stunted turn → `STATE_FAILED` + status message + no reply artifact + failure metrics (never completions). `tsc --noEmit` clean; 309 passing / 3 pending here (the two `.env.local` config-test failures are environmental on this machine and reproduce on unmodified `main`).

## Note

`pi-subagent`'s runner (`extensions/runner.ts`) has the same two patterns (`compaction: { enabled: false }`, race settled on `agent_end`) and would benefit from the same treatment — not bundled here.
