### PR TITLE
fix(pi-a2a): render inbound protocol tasks as dispatches, not "tasks"

### DIFF
--- a/pi-a2a/README.md
+++ b/pi-a2a/README.md
@@ -324,13 +324,18 @@ Or per-terminal via env: `A2A_SELF_IDENTITY=session-a`.
 When a remote peer sends Pi an A2A task, the **host session** now shows what's
 happening — you no longer wonder whether Pi is silently doing work:
 
-- **Arrival** — `[A2A inbound] task from <peer>: <preview>` transcript message
-  + a toast.
+- **Arrival** — `[A2A inbound] dispatch from <peer>: <preview>` transcript
+  message + a toast.
 - **Progress** — the isolated session's tool calls and assistant text deltas
   appear as compact one-line transcript messages (`⚙ bash …`, `✎ …`).
-- **Completion** — `[A2A inbound] task <id> completed (12.3s) — <reply preview>`
-  or `failed: <error>` toast + message. A footer status line shows how many
-  inbound tasks are in flight and from whom.
+- **Completion** — `[A2A inbound] A2A dispatch <label> completed (12.3s) —
+  <reply preview>` or `failed: <error>` toast + message. A footer status line
+  shows how many inbound dispatches are in flight and from whom.
+
+Protocol task ids are labeled as dispatches (`task-1b4f8d1c30d54819` →
+`a2a-1b4`) so a delegated execution reads as one peer-to-peer dispatch, not
+a todo-list item; the raw id stays in the audit log. Transcripts written by
+older versions say `task from` / `task <id> completed` — same meaning.
 
 Toggle with `a2a.ui.transcript` (default `true`):
 

--- a/pi-a2a/extensions/index.ts
+++ b/pi-a2a/extensions/index.ts
@@ -28,7 +28,7 @@ import {
 } from "./lib/client";
 import { A2AServer, type SessionRunner } from "./lib/server";
 import { formatPeers, listPeers } from "./lib/discovery";
-import { activityLine, activityStatusLine, activityToText, classifyLine, preview, type InboundActivity } from "./lib/activity";
+import { activityLine, activityStatusLine, activityToText, classifyLine, dispatchLabel, preview, type InboundActivity } from "./lib/activity";
 import { openPanel, type PanelAction } from "./lib/config-panel";
 
 import { Container, Text } from "@earendil-works/pi-tui";
@@ -203,7 +203,7 @@ function broadcastActivity(
     case "arrived":
       activeInboundTasks.set(a.taskId, { identity: a.identity, last: a });
       // Toast stays short (it would flood the TUI); the transcript carries full text.
-      ctx.ui.notify(`A2A task from ${a.identity}: ${preview(a.text, 160)}`, "info");
+      ctx.ui.notify(`A2A dispatch from ${a.identity}: ${preview(a.text, 160)}`, "info");
       break;
     case "progress":
       activeInboundTasks.set(a.taskId, { identity: activeInboundTasks.get(a.taskId)?.identity ?? "peer", last: a });
@@ -213,8 +213,8 @@ function broadcastActivity(
       activeInboundTasks.delete(a.taskId);
       ctx.ui.notify(
         a.type === "completed"
-          ? `A2A task ${a.taskId.slice(0, 8)} completed (${(a.elapsedMs / 1000).toFixed(1)}s)`
-          : `A2A task ${a.taskId.slice(0, 8)} failed: ${a.error}`,
+          ? `A2A dispatch ${dispatchLabel(a.taskId)} completed (${(a.elapsedMs / 1000).toFixed(1)}s)`
+          : `A2A dispatch ${dispatchLabel(a.taskId)} failed: ${a.error}`,
         a.type === "completed" ? "info" : "error",
       );
       break;
@@ -596,7 +596,7 @@ export default function a2aExtension(pi: ExtensionAPI): void {
         `Name: ${server?.name ?? (cfg.server.agentName || "(default: <hostname>-<port> once started)")}`,
         `Server: ${server ? "running at " + server.url : cfg.server.enabled ? "enabled (not started)" : "disabled"}`,
         `Outbound: ${m.outbound_total} sent / ${m.inbound_total} replies`,
-        `Tasks: ${m.tasks_completed} completed, ${m.tasks_failed} failed`,
+        `Dispatches: ${m.tasks_completed} completed, ${m.tasks_failed} failed`,
         `Avg latency: ${m.avg_latency_ms}ms`,
       ];
       ctx.ui.notify(lines.join("\n"), "info");

--- a/pi-a2a/extensions/lib/activity.ts
+++ b/pi-a2a/extensions/lib/activity.ts
@@ -106,6 +106,18 @@ function argsPreview(args: unknown): string {
   return "";
 }
 
+/** Human-facing label for an A2A protocol Task id.
+ *
+ * The protocol calls each delegated unit of work a "Task", and its raw
+ * ids ("task-1b4f8d1c30d54819") read like todo-list entries when rendered
+ * verbatim ("task task-1b4 …"). Human-facing lines therefore label
+ * protocol tasks as dispatches — one delegation/execution from a peer:
+ * "task-1b4f8d1c30d54819" → "a2a-1b4" ("A2A dispatch a2a-1b4 completed").
+ * The raw protocol id stays in audit-log lines and debug receipts. */
+export function dispatchLabel(taskId: string): string {
+  return `a2a-${taskId.replace(/^task-/, "").slice(0, 3)}`;
+}
+
 // ---------------------------------------------------------------------------
 // Transcript message rendering (terse text the host LLM sees)
 // ---------------------------------------------------------------------------
@@ -114,13 +126,13 @@ function argsPreview(args: unknown): string {
 export function activityToText(a: InboundActivity): string {
   switch (a.type) {
     case "arrived":
-      return `[A2A inbound] task from ${a.identity}:\n${a.text || "(empty)"}`;
+      return `[A2A inbound] dispatch from ${a.identity}:\n${a.text || "(empty)"}`;
     case "progress":
       return `[A2A inbound] ${a.line}`;
     case "completed":
-      return `[A2A inbound] task ${a.taskId.slice(0, 8)} completed (${(a.elapsedMs / 1000).toFixed(1)}s) — ${a.replyPreview || "(no reply)"}`;
+      return `[A2A inbound] A2A dispatch ${dispatchLabel(a.taskId)} completed (${(a.elapsedMs / 1000).toFixed(1)}s) — ${a.replyPreview || "(no reply)"}`;
     case "failed":
-      return `[A2A inbound] task ${a.taskId.slice(0, 8)} failed (${(a.elapsedMs / 1000).toFixed(1)}s): ${a.error || "unknown error"}`;
+      return `[A2A inbound] A2A dispatch ${dispatchLabel(a.taskId)} failed (${(a.elapsedMs / 1000).toFixed(1)}s): ${a.error || "unknown error"}`;
   }
 }
 
@@ -136,21 +148,26 @@ export type A2ALineClass = "received" | "executing" | "replying" | "completed" |
 /** Classify a rendered activity line by shape. Pure — unit-testable, and the
  *  renderer stays a thin color map. Order matters: the explicit ✎/completed/
  *  failed prefixes (which may wrap MULTI-LINE reply/error text) are checked
- *  before the generic received/executing shapes. */
+ *  before the generic received/executing shapes.
+ *
+ *  Lines rendered by older versions say "task from …" / "task … completed";
+ *  current lines say "dispatch from …" / "A2A dispatch … completed". Hosts
+ *  re-render HISTORICAL transcript lines after a restart, so both shapes
+ *  must keep classifying. */
 export function classifyLine(content: string): A2ALineClass {
-  if (/^\[A2A inbound\] task from /.test(content)) return "received";
+  if (/^\[A2A inbound\] (?:task|dispatch) from /.test(content)) return "received";
   if (/^\[A2A inbound\] ✎ /.test(content)) return "replying";
-  if (/^\[A2A inbound\] task .+ completed /.test(content)) return "completed";
-  if (/^\[A2A inbound\] task .+ failed /.test(content)) return "failed";
+  if (/^\[A2A inbound\] (?:task|A2A dispatch) .+ completed /.test(content)) return "completed";
+  if (/^\[A2A inbound\] (?:task|A2A dispatch) .+ failed /.test(content)) return "failed";
   // Multi-line with no recognized prefix = the arrived task text itself.
   if (content.includes("\n")) return "received";
   return "executing"; // ⚙ tool runs, “✓ agent finished”, anything else mid-flight
 }
 
-/** Short footer status while tasks are running (e.g. "2 inbound · 3 tools"). */
+/** Short footer status while dispatches are running (e.g. "A2A: 2 inbound dispatches (hermes)"). */
 export function activityStatusLine(active: Array<{ taskId: string; identity: string }>): string | undefined {
   if (active.length === 0) return undefined;
   const n = active.length;
   const who = active.map((t) => t.identity).join(", ");
-  return `A2A: ${n} inbound task${n > 1 ? "s" : ""} (${who})`;
+  return `A2A: ${n} inbound dispatch${n > 1 ? "es" : ""} (${who})`;
 }

--- a/pi-a2a/extensions/test/activity.test.ts
+++ b/pi-a2a/extensions/test/activity.test.ts
@@ -5,6 +5,7 @@ import {
   activityStatusLine,
   activityToText,
   classifyLine,
+  dispatchLabel,
   preview,
   type InboundActivity,
 } from "../lib/activity";
@@ -60,14 +61,30 @@ describe("activity", () => {
     });
   });
 
+  describe("dispatchLabel", () => {
+    it("renders protocol task ids as dispatch labels", () => {
+      assert.equal(dispatchLabel("task-1b4f8d1c30d54819"), "a2a-1b4");
+      assert.equal(dispatchLabel("t1"), "a2a-t1");
+      assert.equal(dispatchLabel(""), "a2a-");
+    });
+  });
+
   describe("activityToText", () => {
-    it("formats arrived", () => {
+    it("formats arrived as a dispatch", () => {
       const a: InboundActivity = { type: "arrived", taskId: "t1", identity: "hermes", text: "find TODOs", contextId: "c1" };
-      assert.equal(activityToText(a), "[A2A inbound] task from hermes:\nfind TODOs");
+      assert.equal(activityToText(a), "[A2A inbound] dispatch from hermes:\nfind TODOs");
     });
     it("formats completed with elapsed", () => {
       const a: InboundActivity = { type: "completed", taskId: "t1", state: "completed", replyPreview: "done", elapsedMs: 2500 };
       assert.match(activityToText(a), /completed \(2\.5s\) — done/);
+    });
+    it("renders completed as an A2A dispatch, not a task", () => {
+      const a: InboundActivity = { type: "completed", taskId: "task-1b4f8d1c30d54819", state: "completed", replyPreview: "done", elapsedMs: 2500 };
+      assert.equal(activityToText(a), "[A2A inbound] A2A dispatch a2a-1b4 completed (2.5s) — done");
+    });
+    it("renders failed as an A2A dispatch", () => {
+      const a: InboundActivity = { type: "failed", taskId: "task-1b4f8d1c30d54819", error: "boom", elapsedMs: 1000 };
+      assert.equal(activityToText(a), "[A2A inbound] A2A dispatch a2a-1b4 failed (1.0s): boom");
     });
     it("formats failed", () => {
       const a: InboundActivity = { type: "failed", taskId: "t1", error: "boom", elapsedMs: 1000 };
@@ -79,12 +96,15 @@ describe("activity", () => {
     it("returns undefined when no active tasks", () => {
       assert.equal(activityStatusLine([]), undefined);
     });
-    it("summarizes active tasks with identities", () => {
+    it("summarizes active dispatches with identities", () => {
       const line = activityStatusLine([
         { taskId: "t1", identity: "hermes" },
         { taskId: "t2", identity: "session-b" },
       ]);
-      assert.equal(line, "A2A: 2 inbound tasks (hermes, session-b)");
+      assert.equal(line, "A2A: 2 inbound dispatches (hermes, session-b)");
+    });
+    it("uses the singular dispatch for one active", () => {
+      assert.equal(activityStatusLine([{ taskId: "t1", identity: "hermes" }]), "A2A: 1 inbound dispatch (hermes)");
     });
   });
 
@@ -96,6 +116,13 @@ describe("activity", () => {
       assert.equal(classifyLine("[A2A inbound] ✎ here is the list"), "replying");
       assert.equal(classifyLine("[A2A inbound] task t1 comp completed (2.5s) — done"), "completed");
       assert.equal(classifyLine("[A2A inbound] task t1 comp failed (1.0s): boom"), "failed");
+    });
+    it("classifies the dispatch vocabulary", () => {
+      assert.equal(classifyLine("[A2A inbound] dispatch from hermes:\nfind TODOs"), "received");
+      assert.equal(classifyLine("[A2A inbound] A2A dispatch a2a-1b4 completed (2.5s) — done"), "completed");
+      assert.equal(classifyLine("[A2A inbound] A2A dispatch a2a-1b4 failed (1.0s): boom"), "failed");
+      assert.equal(classifyLine("[A2A inbound] A2A dispatch a2a-1b4 failed (1.0s): boom\nstack"), "failed");
+      assert.equal(classifyLine("[A2A inbound] A2A dispatch a2a-1b4 completed (1.0s) — a\nb"), "completed");
     });
     it("multi-line prefixes classify by prefix, not by newline", () => {
       // Real replies and error stacks are multi-line — the prefix wins.


### PR DESCRIPTION
## The problem

The TUI renders inbound A2A protocol Tasks verbatim, raw ids and all:

- transcript: `[A2A inbound] task from hermes:` and `[A2A inbound] task task-1b4f8d1c30d54819 completed (12.3s) — <reply>` (the id was `slice(0, 8)`-shortened, which keeps the `task-` prefix)
- toasts: `A2A task task-1b4 completed (12.3s)`
- footer: `A2A: 2 inbound tasks (hermes)`
- `/a2a-status`: `Tasks: 12 completed, 1 failed`

The protocol calls each delegated unit of work a *Task*, but that word already means "work item" to a human reading the screen. `task task-1b4 completed` reads like "todo item 1b4 done", when an A2A Task is really **one delegation/execution from a peer** — an execution id, not a work-item identity. In a host session that also shows other task-ish things, the two readings collide constantly.

## The change

Human-facing lines now label protocol tasks as **dispatches**:

- `[A2A inbound] dispatch from hermes:`
- `[A2A inbound] A2A dispatch a2a-1b4 completed (12.3s) — <reply>`
- toasts: `A2A dispatch a2a-1b4 …` · footer: `A2A: 2 inbound dispatches (hermes)` (singular `dispatch` for one)
- `/a2a-status`: `Dispatches: 12 completed, 1 failed`

New pure helper `dispatchLabel(taskId)` maps `task-1b4f8d1c30d54819` → `a2a-1b4`: it drops the `task-` prefix (the part doing the misreading) and keeps the same 3 id chars the old `slice(0, 8)` truncation kept — same information content, no double "task task".

The wire format is untouched: the raw protocol id stays in the audit log and debug receipts, so audit↔transcript joins on `taskId` keep working. Only the human-facing strings move.

`classifyLine()` accepts **both** the new and the old shapes — hosts re-render historical transcript lines after a restart, so sessions written before this change keep their UX colors.

The README's inbound-activity section is updated to the new wording (with a one-line note for reading older transcripts).

## Tests

- `dispatchLabel`: id shortening, no-prefix and empty edge cases
- exact-match renderings for completed + failed (these were regex-only before)
- `dispatch from` arrival, singular/plural footer
- classification of both old (`task …`) and new (`A2A dispatch …`) line shapes

`tsc --noEmit` clean. Suite: 326 passing / 3 pending / 2 failing on this branch vs **321/3/2 on unmodified `main`** (+5 new tests, zero new failures; the two `.env.local` config failures are environmental on this machine and reproduce identically on `main`).
