### PR TITLE
feat(pi-a2a): send asserted X-A2A-Identity header on outbound peer requests

### DIFF
--- a/pi-a2a/README.md
+++ b/pi-a2a/README.md
@@ -319,6 +319,24 @@ Or per-terminal via env: `A2A_SELF_IDENTITY=session-a`.
 - Sessions still reach each other: A presents `tokenA`, B's server looks it up
   → identity `session-a`; no caller needs anyone else's token.
 
+### Outbound asserted identity (X-A2A-Identity)
+
+Every outbound peer request carries the caller's configured identity
+(`selfIdentity`, falling back to `server.agentName`) as an
+`X-A2A-Identity` header, in addition to the `pi/self` message metadata. The
+use case: when peers live behind a reverse proxy (or on other machines
+reached through one), every caller arrives from the proxy's address —
+`ip:127.0.0.1` tells the receiver nothing about WHICH agent dispatched. The
+header lets a receiving peer's audit log attribute the call to a name
+(`pi-kimchi`, `librarian-bingsu`, …) instead of the address.
+
+- **Asserted display provenance, never authentication.** Any client can send
+  any name; a receiving server must only use it to refine the display name of
+  a caller it has ALREADY admitted (e.g. an authenticated shared-token
+  caller), never to grant admission or override a token-authenticated
+  identity. Receivers that don't know the header simply ignore it.
+- The header is omitted when no identity is configured (both empty).
+
 ### Inbound activity in the host TUI (0.3.0)
 
 When a remote peer sends Pi an A2A task, the **host session** now shows what's
@@ -405,6 +423,9 @@ and **UI** (transcript toggle).
   untrusted peer input. Remote peers cannot invoke operator slash commands.
 - **Outbound redaction** — credential-shaped strings (API keys, JWTs, tokens,
   emails) are scrubbed from replies before they leave.
+- **Asserted identity is display-only** — the `X-A2A-Identity` header sent
+  outbound names the caller for attribution; it is self-reported, carries no
+  credential, and must never be trusted for admission on the receiving side.
 - **Untrusted metadata sanitized** — mDNS TXT records and registry files are
   network/world-readable input; peer names/cwd/model are sanitized
   (single-line, length-capped) before display.

--- a/pi-a2a/extensions/lib/client.ts
+++ b/pi-a2a/extensions/lib/client.ts
@@ -339,6 +339,15 @@ async function sendTask(opts: {
 }): Promise<SendResult> {
   const { cfg, piDir, peer, agentLabel, message } = opts;
   const headers = authHeaders(peer);
+  // Asserted sender identity (X-A2A-Identity): lets the receiving peer
+  // attribute this dispatch to a NAME (e.g. "pi-kimchi") instead of the
+  // caller's address — behind a reverse proxy every caller shares the
+  // proxy's loopback address, so address attribution cannot tell agents
+  // apart. Advisory display provenance only, mirroring the "pi/self"
+  // message metadata below: the receiver's own trust gates decide whether
+  // to honor it — never authentication. Unset identity → header omitted.
+  const self = cfg.selfIdentity || cfg.server.agentName;
+  if (self) headers["X-A2A-Identity"] = self;
   // Advisory caller attribution for the gateway's routing log/dashboard.
   // Self-declared display name — stripped by the gateway before forwarding.
   if (peer.viaGateway) {

--- a/pi-a2a/extensions/test/client.test.ts
+++ b/pi-a2a/extensions/test/client.test.ts
@@ -165,6 +165,60 @@ describe("client", () => {
       assert.isUndefined(seenHeaders["X-Gateway-Caller"]);
     });
 
+    it("sends the asserted X-A2A-Identity header from selfIdentity", async () => {
+      const result = { task: { id: "t", contextId: "c", status: { state: STATE_COMPLETED }, artifacts: [{ parts: [{ text: "ok" }] }] } };
+      let seenHeaders: Record<string, string> = {};
+      globalThis.fetch = (async (_url: string, init?: any) => {
+        seenHeaders = { ...(init?.headers || {}) };
+        return {
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify({ jsonrpc: "2.0", id: 1, result }),
+        };
+      }) as any;
+      const cfg = DEFAULTS();
+      cfg.selfIdentity = "pi-kimchi";
+      cfg.peers.bob = { url: "http://b", auth: { type: "none" }, timeout: 5000, capabilities: [] };
+      const out = await a2aCall({ cfg, piDir, agent: "bob", message: "hi" });
+      assert.include(out, "ok");
+      assert.equal(seenHeaders["X-A2A-Identity"], "pi-kimchi");
+    });
+
+    it("falls back to server.agentName for X-A2A-Identity", async () => {
+      const result = { task: { id: "t", contextId: "c", status: { state: STATE_COMPLETED }, artifacts: [{ parts: [{ text: "ok" }] }] } };
+      let seenHeaders: Record<string, string> = {};
+      globalThis.fetch = (async (_url: string, init?: any) => {
+        seenHeaders = { ...(init?.headers || {}) };
+        return {
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify({ jsonrpc: "2.0", id: 1, result }),
+        };
+      }) as any;
+      const cfg = DEFAULTS();
+      cfg.server.agentName = "pi-bingsu"; // selfIdentity unset
+      cfg.peers.bob = { url: "http://b", auth: { type: "none" }, timeout: 5000, capabilities: [] };
+      await a2aCall({ cfg, piDir, agent: "bob", message: "hi" });
+      assert.equal(seenHeaders["X-A2A-Identity"], "pi-bingsu");
+    });
+
+    it("omits X-A2A-Identity when no identity is configured", async () => {
+      const result = { task: { id: "t", contextId: "c", status: { state: STATE_COMPLETED }, artifacts: [{ parts: [{ text: "ok" }] }] } };
+      let seenHeaders: Record<string, string> = {};
+      globalThis.fetch = (async (_url: string, init?: any) => {
+        seenHeaders = { ...(init?.headers || {}) };
+        return {
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify({ jsonrpc: "2.0", id: 1, result }),
+        };
+      }) as any;
+      const cfg = DEFAULTS(); // selfIdentity and server.agentName both ""
+      cfg.peers.bob = { url: "http://b", auth: { type: "none" }, timeout: 5000, capabilities: [] };
+      await a2aCall({ cfg, piDir, agent: "bob", message: "hi" });
+      assert.isUndefined(seenHeaders["X-A2A-Identity"]);
+    });
+
     it("falls back to the runtime gateway registration name for X-Gateway-Caller", async () => {
       const result = { task: { id: "t", contextId: "c", status: { state: STATE_COMPLETED }, artifacts: [{ parts: [{ text: "ok" }] }] } };
       let seenHeaders: Record<string, string> = {};


### PR DESCRIPTION
## The problem

When peers live behind a reverse proxy (or on other machines reached through one), every caller arrives at the receiving A2A server **from the proxy's address** — typically `127.0.0.1`. Address-based attribution then can't tell WHICH agent dispatched: the audit log shows `ip:127.0.0.1` for every caller, and with more than one agent on the network there is no way to tell them apart after the fact.

Pi already sends its configured identity as `pi/self` **message metadata** on every outbound message, but message metadata is payload — an inbound server's auth layer never sees it, so it cannot drive audit attribution. The same information needs to be on the transport layer, where the receiving side resolves identity.

Hermes's A2A implementation already sends an `X-A2A-Identity` header on its outbound peer requests for exactly this reason; pi→pi and pi→other dispatches were the remaining gap.

## The change

`sendTask()` (the single funnel behind `a2a_call`, `a2a_orchestrate`, and `/a2a-send`) now sets one extra header on every outbound peer request:

```ts
const self = cfg.selfIdentity || cfg.server.agentName;
if (self) headers["X-A2A-Identity"] = self;
```

- Value: the caller's configured identity (`selfIdentity`, falling back to `server.agentName`) — e.g. `pi-kimchi`. Omitted entirely when neither is configured.
- Sent on the agent-card fetch too (it shares the same headers object as the JSON-RPC POST, matching how auth headers are already treated).
- Same precedence as the existing `X-Gateway-Caller` advisory header.

**Asserted display provenance, never authentication.** Any client can send any name; the header carries no credential. A receiving server must only use it to refine the display name of a caller it has **already admitted** (e.g. an authenticated shared-token caller) — never to grant admission and never to override a token-authenticated identity. Receivers that don't know the header ignore it. The README documents this contract.

## Tests

Three new cases in `client.test.ts` (mock-fetch captures the outgoing headers, mirroring the existing `X-Gateway-Caller` tests):

- sends `X-A2A-Identity` from `selfIdentity`
- falls back to `server.agentName` when `selfIdentity` is unset
- omits the header when no identity is configured

`tsc --noEmit` clean. Suite: 331 passing / 3 pending / 2 failing on this branch vs **328/3/2 on unmodified `main`** (+3 new tests, zero new failures; the two `.env.local` config failures are environmental on this machine and reproduce identically on `main`).

## Live verification

Verified end-to-end against a second pi host exposed through a reverse proxy (bind `127.0.0.1` behind a `tailscale serve` TLS proxy — the exact "all callers share the proxy's loopback address" scenario): an A/B pair of throwaway pi hosts dispatching the same message, identical peer config, the only difference being this patch — pre-patch bytes arrive in the receiver's audit log as `identity: ip:127.0.0.1`, patched bytes as `identity: pi-kimchi` (the receiver's existing trust gates honored the header for the authenticated loopback caller).
