### PR TITLE
feat(pi-a2a): non-blocking async dispatch (returnImmediately) + a2a_status polling

### DIFF
--- a/pi-a2a/README.md
+++ b/pi-a2a/README.md
@@ -78,10 +78,10 @@ Edit `~/.pi/agent/settings.json` under the `a2a` key. Key reference:
 | `server.peerTokens` | `{}` | Per-peer token directory `name → token` (unique identities) |
 | `server.trustedPeers` | `[]` | Allow-list of authenticated identities |
 | `server.allowAllUsers` | `false` | Allow any authenticated peer (dev only) |
-| `server.maxConcurrent` | `3` | Max concurrent inbound tasks |
-| `server.replyTimeoutSec` | `300` | Seconds to wait for the agent's reply |
 | `server.childTranscripts` | `true` | Persist each dispatched child session's transcript to `<agentDir>/a2a_sessions/<timestamp>_<taskId>.jsonl` (a real pi session file, openable with pi's session tooling) so stalled/killed workers leave a forensic step history. Off = stock in-memory children |
 | `server.childTranscriptRetentionDays` | `30` | Delete child transcripts older than N days on server start. `0` = keep forever. Transcripts carry everything the worker read — keep the window bounded |
+| `server.maxConcurrent` | `3` | Max concurrent inbound tasks (blocking **and** detached — see the operator note under [Non-blocking dispatch](#non-blocking-dispatch-returnimmediately)) |
+| `server.replyTimeoutSec` | `300` | Seconds to wait for the agent's reply on a blocking send. `0` = no reply-window timer (unbounded — the request stays open until the run settles; deliberate, rare) |
 | `server.asyncTimeoutSec` | `86400` | Supervision window (seconds) for **detached** tasks sent with `returnImmediately` — the caller's request already returned an ack, so this bound replaces the reply window. `0` = unbounded (caller-supervised via `tasks/get` / `tasks/cancel`) |
 | `server.maxPingpongTurns` | `5` | Anti-loop turn cap per context (max 20) |
 | `server.rateLimitPerMin` | `60` | Requests/minute per identity |
@@ -172,7 +172,7 @@ on an inbound agent server on whoever opens it. (`portFallback: 0` means
 | `A2A_ALLOW_ALL_USERS` | `false` | Allow any authenticated peer (dev only) |
 | `A2A_RATE_LIMIT` | `60` | Requests/minute per identity |
 | `A2A_MAX_PINGPONG_TURNS` | `5` | Anti-loop turn cap per context (max 20) |
-| `A2A_REPLY_TIMEOUT` | `300` | Seconds to wait for the agent's reply |
+| `A2A_REPLY_TIMEOUT` | `300` | Seconds to wait for the agent's reply (`0` = unbounded: no reply-window timer) |
 | `A2A_ASYNC_TIMEOUT` | `86400` | Detached-task supervision window in seconds (`0` = unbounded) — see [Non-blocking dispatch](#non-blocking-dispatch-returnimmediately) |
 | `A2A_SERVER_ENABLED` | `false` | Auto-start the inbound server on session start |
 | `A2A_SELF_IDENTITY` | _(unset)_ | Outbound caller identity: a key in `server.peerTokens`. When set, this session presents its OWN per-peer token (not the shared token) so receivers attribute calls to it uniquely. Empty = use the shared token (anonymous caller). |
@@ -514,6 +514,17 @@ a2a_status(agent="worker", task_id="task-1b4f…", wait_seconds=300)  # poll unt
   ones, and overflow is supervised by `server.asyncTimeoutSec` (default
   24h, `0` = unbounded/caller-supervised) → `TASK_STATE_FAILED` with a
   descriptive status message, mirroring the reply-window semantics.
+- **Operator note — a detached run pins a concurrency slot for its whole
+  lifetime.** The gate runs *before* the blocking/detached split, and a
+  detached run holds its `maxConcurrent` slot from the ack until it reaches
+  a terminal state — up to `asyncTimeoutSec` (24h by default) each. Three
+  slow or hung detached dispatches at the default `maxConcurrent: 3`
+  therefore block **all** inbound work — blocking `message/send` included
+  (`server busy`) — until they drain. Levers: keep `asyncTimeoutSec` as low
+  as your longest legitimate detached job (it is the kill switch that frees
+  the slot), raise `maxConcurrent` if you routinely dispatch long jobs, and
+  `tasks/cancel` a stuck task to free its slot immediately. (A separate
+  `maxDetached` budget is a plausible follow-up.)
 - `returnImmediately` has **no effect on `message/stream`** (per §3.2.2) —
   streaming keeps its blocking semantics.
 - The snake_case spelling `return_immediately` is accepted for early

--- a/pi-a2a/README.md
+++ b/pi-a2a/README.md
@@ -82,6 +82,7 @@ Edit `~/.pi/agent/settings.json` under the `a2a` key. Key reference:
 | `server.replyTimeoutSec` | `300` | Seconds to wait for the agent's reply |
 | `server.childTranscripts` | `true` | Persist each dispatched child session's transcript to `<agentDir>/a2a_sessions/<timestamp>_<taskId>.jsonl` (a real pi session file, openable with pi's session tooling) so stalled/killed workers leave a forensic step history. Off = stock in-memory children |
 | `server.childTranscriptRetentionDays` | `30` | Delete child transcripts older than N days on server start. `0` = keep forever. Transcripts carry everything the worker read — keep the window bounded |
+| `server.asyncTimeoutSec` | `86400` | Supervision window (seconds) for **detached** tasks sent with `returnImmediately` — the caller's request already returned an ack, so this bound replaces the reply window. `0` = unbounded (caller-supervised via `tasks/get` / `tasks/cancel`) |
 | `server.maxPingpongTurns` | `5` | Anti-loop turn cap per context (max 20) |
 | `server.rateLimitPerMin` | `60` | Requests/minute per identity |
 | `server.skills` | `[]` | Skills advertised on the Agent Card. When empty (default), skills are **self-discovered** from the live session — no config needed |
@@ -172,6 +173,7 @@ on an inbound agent server on whoever opens it. (`portFallback: 0` means
 | `A2A_RATE_LIMIT` | `60` | Requests/minute per identity |
 | `A2A_MAX_PINGPONG_TURNS` | `5` | Anti-loop turn cap per context (max 20) |
 | `A2A_REPLY_TIMEOUT` | `300` | Seconds to wait for the agent's reply |
+| `A2A_ASYNC_TIMEOUT` | `86400` | Detached-task supervision window in seconds (`0` = unbounded) — see [Non-blocking dispatch](#non-blocking-dispatch-returnimmediately) |
 | `A2A_SERVER_ENABLED` | `false` | Auto-start the inbound server on session start |
 | `A2A_SELF_IDENTITY` | _(unset)_ | Outbound caller identity: a key in `server.peerTokens`. When set, this session presents its OWN per-peer token (not the shared token) so receivers attribute calls to it uniquely. Empty = use the shared token (anonymous caller). |
 | `A2A_DISCOVERY_LOCAL` | `true` | Enable the local file registry |
@@ -389,7 +391,8 @@ and **UI** (transcript toggle).
 
 | Tool | What it does |
 |------|--------------|
-| `a2a_call(agent, message, context_id?)` | Send a task to a peer, return its reply; multi-turn via `context_id` |
+| `a2a_call(agent, message, context_id?, async_dispatch?)` | Send a task to a peer, return its reply; multi-turn via `context_id`. `async_dispatch: true` returns an ack with the task id immediately (see [Non-blocking dispatch](#non-blocking-dispatch-returnimmediately)) |
+| `a2a_status(agent, task_id, wait_seconds?)` | Poll a previously dispatched task by id (GetTask); with `wait_seconds`, poll until terminal or deadline |
 | `a2a_discover(url)` | Fetch and summarize a peer's Agent Card |
 | `a2a_list()` | Configured peers, persisted conversations, metrics |
 | `a2a_history(context_id, limit?)` | Recall a persisted conversation |
@@ -464,6 +467,62 @@ no text, and the task would otherwise complete with the *previous* turn's
 stale reply. Such a turn now fails the task (`FAILED`, status message
 "no usable reply was produced") instead of masquerading as success.
 
+## Non-blocking dispatch (returnImmediately)
+
+A blocking `message/send` holds the HTTP request open until the agent finishes
+— so the caller's reply window bounds the **worker's** runtime: a long job
+(reindex, multi-file refactor, an ops run) gets killed when the caller stops
+waiting, even though the caller only wanted to submit it.
+
+A2A v1.0 §3.2.2 `SendMessageConfiguration.returnImmediately` decouples the
+two. On the wire it is one extra field:
+
+```jsonc
+{
+  "jsonrpc": "2.0", "id": 1, "method": "message/send",
+  "params": {
+    "message": { "role": "ROLE_USER", "parts": [{ "text": "long job" }] },
+    "configuration": { "returnImmediately": true }
+  }
+}
+```
+
+The server acks immediately with the Task in `TASK_STATE_WORKING` and keeps
+running it **detached** from the request. The ack no longer waits for the
+work; the work no longer dies with the caller's patience. The caller then
+polls `tasks/get` (or cancels via `tasks/cancel`) by task id.
+
+From Pi's tools this is `async_dispatch` + `a2a_status`:
+
+```text
+a2a_call(agent="worker", message="reindex everything", async_dispatch=true)
+# → [A2A → worker · context … · working · detached]
+#   Dispatch accepted — task task-1b4f… is running on the peer (non-blocking).
+#   Poll the result with a2a_status(agent: "worker", task_id: "task-1b4f…").
+
+a2a_status(agent="worker", task_id="task-1b4f…")          # one fetch
+a2a_status(agent="worker", task_id="task-1b4f…", wait_seconds=300)  # poll until terminal
+```
+
+- A peer that does not understand `returnImmediately` simply blocks and
+  returns the finished task — `a2a_call` falls through to the normal reply
+  formatting, so the flag is always safe to send.
+- A **fast** task may complete before the ack is serialized; the ack then
+  carries the terminal state and artifacts (the client treats it as a normal
+  reply — no polling needed).
+- Detached runs count against `server.maxConcurrent` exactly like blocking
+  ones, and overflow is supervised by `server.asyncTimeoutSec` (default
+  24h, `0` = unbounded/caller-supervised) → `TASK_STATE_FAILED` with a
+  descriptive status message, mirroring the reply-window semantics.
+- `returnImmediately` has **no effect on `message/stream`** (per §3.2.2) —
+  streaming keeps its blocking semantics.
+- The snake_case spelling `return_immediately` is accepted for early
+  v1.0-draft clients.
+
+For fleet agents: the natural completion signal is still the shared queue
+(knowfleet) — poll `a2a_status` only to surface progress or fetch artifacts,
+not as the source of truth for whether the worker finished its bookkeeping.
+
 ## Hermes interop
 
 The primary interop target. Hermes (`~/.hermes/hermes-agent`, A2A platform
@@ -493,6 +552,7 @@ results, `{id, state}` list stubs) so existing peers see no change.
 |---------|--------|
 | Agent Card (`/.well-known/agent-card.json`) | ✅ + legacy `agent.json` |
 | `message/send` (sync) | ✅ |
+| `message/send` non-blocking (`configuration.returnImmediately`) | ✅ (see [Non-blocking dispatch](#non-blocking-dispatch-returnimmediately)) |
 | `message/stream` (SSE) | ✅ |
 | `tasks/get`, `tasks/list`, `tasks/cancel`, `tasks/subscribe` | ✅ |
 | Part types (text, file, data) | ✅ (v1.0 + v0.3 tolerant) |

--- a/pi-a2a/extensions/index.ts
+++ b/pi-a2a/extensions/index.ts
@@ -548,12 +548,12 @@ export default function a2aExtension(pi: ExtensionAPI): void {
       }),
       wait_seconds: Type.Optional(
         Type.Number({
-          description: "If set, poll until the task is terminal or this many seconds pass. " +
-          "Omit for a single status fetch.",
+          description: "If positive, poll until the task is terminal or this many seconds pass. " +
+          "Omit (or 0/negative) for a single status fetch.",
         }),
       ),
     }),
-    execute: async (_id, args, _signal, _onUpdate, ctx) => {
+    execute: async (_id, args, signal, _onUpdate, ctx) => {
       const cfg = cfgFor(ctx);
       return {
         content: [
@@ -566,6 +566,7 @@ export default function a2aExtension(pi: ExtensionAPI): void {
               taskId: String(args.task_id ?? ""),
               waitSeconds: typeof args.wait_seconds === "number" ? args.wait_seconds : undefined,
               discoveredPeers: listPeers({ cfg, piDir: piDir(), mdnsPeers: server?.discoveredMdnsPeers ?? [], selfUrl: server?.url ?? "", gatewayPeers: getGatewayPeers() }),
+              signal: signal ?? undefined,
             }),
           },
         ],

--- a/pi-a2a/extensions/index.ts
+++ b/pi-a2a/extensions/index.ts
@@ -25,6 +25,7 @@ import {
   a2aHistory,
   a2aList,
   a2aOrchestrate,
+  a2aStatus,
   metrics,
 } from "./lib/client";
 import { A2AServer, type SessionRunner } from "./lib/server";
@@ -480,16 +481,29 @@ export default function a2aExtension(pi: ExtensionAPI): void {
     description:
       "Call a remote A2A (Agent2Agent) agent with a task message and return its reply. " +
       "Use to delegate work to other agents (Hermes, ADK, LangChain, CrewAI, any A2A peer). " +
-      "Pass context_id to continue a multi-turn conversation.",
+      "Pass context_id to continue a multi-turn conversation. Set async_dispatch true for " +
+      "long-running work: the call returns an ack with a task id immediately and the peer " +
+      "keeps working — poll it with a2a_status.",
     promptSnippet: "delegate a task to a remote A2A agent and get its reply",
     promptGuidelines: [
       "Use for cross-agent task distribution and specialist delegation.",
       "The agent param is a configured peer name OR a full URL.",
+      "For jobs that may run long, set async_dispatch true — you get a task id back " +
+      "immediately instead of holding the call open; check a2a_status for the result.",
     ],
     parameters: Type.Object({
       agent: agentParam,
       message: messageParam,
       context_id: contextIdParam,
+      async_dispatch: Type.Optional(
+        Type.Boolean({
+          description:
+            "Non-blocking dispatch (A2A v1.0 returnImmediately): return an ack with the task id " +
+            "as soon as the peer accepts, instead of waiting for the work to finish. " +
+            "The peer runs the task detached — poll a2a_status for the result.",
+          default: false,
+        }),
+      ),
     }),
     execute: async (_id, args, _signal, _onUpdate, ctx) => {
       const cfg = cfgFor(ctx);
@@ -503,6 +517,54 @@ export default function a2aExtension(pi: ExtensionAPI): void {
               agent: String(args.agent ?? ""),
               message: String(args.message ?? ""),
               contextId: args.context_id ? String(args.context_id) : undefined,
+              asyncDispatch: args.async_dispatch === true,
+              discoveredPeers: listPeers({ cfg, piDir: piDir(), mdnsPeers: server?.discoveredMdnsPeers ?? [], selfUrl: server?.url ?? "", gatewayPeers: getGatewayPeers() }),
+            }),
+          },
+        ],
+        details: {},
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "a2a_status",
+    label: "A2A Status",
+    description:
+      "Check the status of a task previously dispatched to a remote A2A agent (by task id — " +
+      "see the ack from an async_dispatch a2a_call). Returns the task state, and the reply " +
+      "text once the task is completed/failed. Optionally wait (wait_seconds) and poll until " +
+      "the task reaches a terminal state.",
+    promptSnippet: "poll the status of a task dispatched to a remote A2A agent",
+    promptGuidelines: [
+      "Use after an async_dispatch a2a_call to fetch the result of a long-running task.",
+      "Without wait_seconds it fetches once; with it, the tool polls until the task is " +
+      "terminal or the deadline passes (the task keeps running on the peer either way).",
+    ],
+    parameters: Type.Object({
+      agent: agentParam,
+      task_id: Type.String({
+        description: "Task id from the dispatch ack (e.g. task-1b4f8d1c30d54819).",
+      }),
+      wait_seconds: Type.Optional(
+        Type.Number({
+          description: "If set, poll until the task is terminal or this many seconds pass. " +
+          "Omit for a single status fetch.",
+        }),
+      ),
+    }),
+    execute: async (_id, args, _signal, _onUpdate, ctx) => {
+      const cfg = cfgFor(ctx);
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: await a2aStatus({
+              cfg,
+              piDir: piDir(),
+              agent: String(args.agent ?? ""),
+              taskId: String(args.task_id ?? ""),
+              waitSeconds: typeof args.wait_seconds === "number" ? args.wait_seconds : undefined,
               discoveredPeers: listPeers({ cfg, piDir: piDir(), mdnsPeers: server?.discoveredMdnsPeers ?? [], selfUrl: server?.url ?? "", gatewayPeers: getGatewayPeers() }),
             }),
           },
@@ -1032,7 +1094,7 @@ export default function a2aExtension(pi: ExtensionAPI): void {
           "  /a2a-config show             Show config summary",
           "  /a2a-server start|stop|status  Manage inbound server",
           "",
-          "Tools: a2a_call, a2a_discover, a2a_list, a2a_history, a2a_orchestrate",
+          "Tools: a2a_call, a2a_status, a2a_discover, a2a_list, a2a_history, a2a_orchestrate",
         ].join("\n"),
         "info",
       );

--- a/pi-a2a/extensions/lib/client.ts
+++ b/pi-a2a/extensions/lib/client.ts
@@ -334,6 +334,23 @@ export interface SendResult {
   taskId?: string;
 }
 
+/** Auth + asserted-identity headers for an outbound request to a peer.
+ *  X-A2A-Identity (selfIdentity, falling back to server.agentName) names the
+ *  caller for the RECEIVING side's audit log / attribution — behind a reverse
+ *  proxy every caller arrives from the proxy's address, so address-based
+ *  attribution cannot tell agents apart. Advisory display provenance only,
+ *  never authentication: any client can assert any name, so a receiver must
+ *  only use it to refine the display of a caller it has ALREADY admitted.
+ *  Omitted when no identity is configured. Shared by EVERY outbound request
+ *  (SendMessage dispatches AND the GetTask polls of a2a_status) so the
+ *  receiver sees the same caller on dispatch and on every later poll. */
+function peerRequestHeaders(cfg: A2AConfig, peer: Peer): Record<string, string> {
+  const headers = authHeaders(peer);
+  const self = cfg.selfIdentity || cfg.server.agentName;
+  if (self) headers["X-A2A-Identity"] = self;
+  return headers;
+}
+
 async function sendTask(opts: {
   cfg: A2AConfig;
   piDir: string;
@@ -347,16 +364,7 @@ async function sendTask(opts: {
   asyncDispatch?: boolean;
 }): Promise<SendResult> {
   const { cfg, piDir, peer, agentLabel, message } = opts;
-  const headers = authHeaders(peer);
-  // Asserted sender identity (X-A2A-Identity): lets the receiving peer
-  // attribute this dispatch to a NAME (e.g. "pi-kimchi") instead of the
-  // caller's address — behind a reverse proxy every caller shares the
-  // proxy's loopback address, so address attribution cannot tell agents
-  // apart. Advisory display provenance only, mirroring the "pi/self"
-  // message metadata below: the receiver's own trust gates decide whether
-  // to honor it — never authentication. Unset identity → header omitted.
-  const self = cfg.selfIdentity || cfg.server.agentName;
-  if (self) headers["X-A2A-Identity"] = self;
+  const headers = peerRequestHeaders(cfg, peer);
   // Advisory caller attribution for the gateway's routing log/dashboard.
   // Self-declared display name — stripped by the gateway before forwarding.
   if (peer.viaGateway) {
@@ -622,7 +630,23 @@ export async function a2aCall(opts: {
 // Task status / polling (GetTask)
 // ---------------------------------------------------------------------------
 
-const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+/** sleep that also resolves when `signal` aborts, so poll waits do not hold
+ *  a canceled tool call open — a2a_status with wait_seconds=300 must stay
+ *  interruptible. */
+function sleepAbortable(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    const t = setTimeout(done, ms);
+    function done(): void {
+      clearTimeout(t);
+      signal?.removeEventListener("abort", done);
+      resolve();
+    }
+    if (signal) {
+      if (signal.aborted) return done();
+      signal.addEventListener("abort", done, { once: true });
+    }
+  });
+}
 
 /** Fetch one task's current state from a peer via GetTask (A2A v1.0). The
  *  peer's per-identity task ownership applies: only the caller that created
@@ -632,7 +656,7 @@ export async function getTask(opts: {
   peer: Peer;
   taskId: string;
 }): Promise<Task> {
-  const headers = authHeaders(opts.peer);
+  const headers = peerRequestHeaders(opts.cfg, opts.peer);
   const timeout = opts.peer.timeout || opts.cfg.timeouts.send;
   // Best-effort card fetch (to learn the rpc URL); non-fatal on failure.
   let card: AgentCard | null = null;
@@ -678,11 +702,17 @@ export async function a2aStatus(opts: {
   piDir: string;
   agent: string;
   taskId: string;
-  /** When set (seconds), poll until the task reaches a terminal state or the
-   *  deadline — polls at cfg.timeouts.async intervals (the documented "async
-   *  task poll interval"). 0/undefined = a single fetch. */
+  /** When POSITIVE (seconds), poll until the task reaches a terminal state
+   *  or the deadline — polls at cfg.timeouts.async intervals (the documented
+   *  "async task poll interval"). 0, negative, or undefined = a single
+   *  fetch. */
   waitSeconds?: number;
   discoveredPeers?: DiscoveredPeer[];
+  /** Aborts the polling loop promptly (tool cancel): checked before each
+   *  fetch, raced into the poll sleep, and re-checked after it — a canceled
+   *  a2a_status with wait_seconds=300 must not hold the tool call open.
+   *  Aborting does NOT affect the task on the peer; it keeps running. */
+  signal?: AbortSignal;
 }): Promise<string> {
   const agent = (opts.agent || "").trim();
   const taskId = (opts.taskId || "").trim();
@@ -695,9 +725,15 @@ export async function a2aStatus(opts: {
   });
   if ("error" in resolved) return resolved.error;
   const peer = resolved.peer;
-  const deadline = Date.now() + Math.max(0, (opts.waitSeconds ?? 0)) * 1000;
+  // Non-positive wait_seconds is treated as "unset" — a single fetch. A
+  // negative value would otherwise poll once, immediately expire, and print
+  // nonsense like "after -5s of polling".
+  const waitSeconds = typeof opts.waitSeconds === "number" && opts.waitSeconds > 0 ? opts.waitSeconds : undefined;
+  const deadline = waitSeconds !== undefined ? Date.now() + waitSeconds * 1000 : 0;
   const interval = Math.max(250, opts.cfg.timeouts.async);
+  let lastTask: Task | null = null;
   for (;;) {
+    if (opts.signal?.aborted) return statusCanceled(agent, taskId, lastTask);
     let task: Task;
     try {
       task = await getTask({ cfg: opts.cfg, peer, taskId });
@@ -709,18 +745,30 @@ export async function a2aStatus(opts: {
       if (/HTTP 401|HTTP 403/.test(msg)) return `Error: peer '${agent}' rejected auth. Check the configured token.`;
       return `Error: status check for '${agent}' task '${taskId}' failed — ${msg}`;
     }
+    lastTask = task;
     const state = normalizeState(task.status?.state);
-    if (TERMINAL_STATES.has(state) || !opts.waitSeconds) {
+    if (TERMINAL_STATES.has(state) || waitSeconds === undefined) {
       return formatTask(task);
     }
     if (Date.now() >= deadline) {
       return (
         formatTask(task) +
-        `\n\n(Still non-terminal after ${opts.waitSeconds}s of polling — the task keeps running on the peer; call a2a_status again later.)`
+        `\n\n(Still non-terminal after ${waitSeconds}s of polling — the task keeps running on the peer; call a2a_status again later.)`
       );
     }
-    await sleep(Math.min(interval, Math.max(0, deadline - Date.now())));
+    await sleepAbortable(Math.min(interval, Math.max(0, deadline - Date.now())), opts.signal);
   }
+}
+
+/** a2a_status's abort message: report the last-known state (the task itself
+ *  is untouched — aborting a poll never touches the peer's run) and how to
+ *  pick the poll back up. */
+function statusCanceled(agent: string, taskId: string, lastTask: Task | null): string {
+  const body = lastTask ? formatTask(lastTask) : `task ${taskId}: status not yet fetched.`;
+  return (
+    body +
+    `\n\n(Status polling canceled — the task keeps running on the peer regardless; call a2a_status(agent: "${agent}", task_id: "${taskId}") again later.)`
+  );
 }
 
 /** Build the set of loopback URLs that are KNOWN peers (same-machine, same-user):

--- a/pi-a2a/extensions/lib/client.ts
+++ b/pi-a2a/extensions/lib/client.ts
@@ -10,6 +10,7 @@
 import {
   PROTOCOL_VERSION,
   STATE_INPUT_REQUIRED,
+  TERMINAL_STATES,
   extractText,
   newContextId,
   newTaskId,
@@ -19,6 +20,7 @@ import {
   unwrapSendMessageResponse,
   type AgentCard,
   type JsonRpcRequest,
+  type Task,
 } from "./protocol";
 import {
   authHeaders,
@@ -327,6 +329,9 @@ export interface SendResult {
   reply: string;
   contextId: string;
   state: string;
+  /** Set when the peer returned a Task (v1.0 wire) — the caller can poll it
+   *  with GetTask (a2a_status). Always present for non-blocking dispatches. */
+  taskId?: string;
 }
 
 async function sendTask(opts: {
@@ -336,6 +341,10 @@ async function sendTask(opts: {
   agentLabel: string;
   message: string;
   contextId?: string;
+  /** Non-blocking dispatch (A2A v1.0 §3.2.2 returnImmediately): the peer
+   *  acks with an in-progress Task and runs the work detached from this
+   *  call — the reply arrives later via GetTask (a2a_status). */
+  asyncDispatch?: boolean;
 }): Promise<SendResult> {
   const { cfg, piDir, peer, agentLabel, message } = opts;
   const headers = authHeaders(peer);
@@ -395,6 +404,7 @@ async function sendTask(opts: {
     method: "SendMessage",
     params: {
       message: textMessage(ROLE_USER, safe, ctx),
+      ...(opts.asyncDispatch ? { configuration: { returnImmediately: true } } : {}),
     },
   };
 
@@ -427,17 +437,25 @@ async function sendTask(opts: {
     throw new Error(`peer '${agentLabel}' returned an error: ${msg}`);
   }
   const result = resp.result ?? {};
+  const payload = unwrapSendMessageResponse(result);
+  const taskId = payload && typeof payload === "object" && payload.id ? String(payload.id) : undefined;
   const reply = replyTextFromResult(result);
   const replyCtx = contextFromResult(result, ctx);
   const state = stateFromResult(result);
   // Persist BOTH the user message and the agent reply under the SAME contextId
   // (replyCtx) so a2a_history returns the complete conversation, not half.
+  // For a non-blocking dispatch the "reply" side is an ack marker — the real
+  // reply arrives later via GetTask (a2a_status).
+  const agentText =
+    opts.asyncDispatch && taskId && !reply
+      ? `(dispatched non-blocking — task ${taskId} is running on the peer; poll with a2a_status)`
+      : reply;
   persistMessage({ piDir, contextId: replyCtx, role: "user", text: safe, taskId: String(rpcBody.id), peer: agentLabel });
-  persistMessage({ piDir, contextId: replyCtx, role: "agent", text: reply, taskId: String(rpcBody.id), peer: agentLabel });
+  persistMessage({ piDir, contextId: replyCtx, role: "agent", text: agentText, taskId: String(rpcBody.id), peer: agentLabel });
   metrics.inboundTotal += 1;
   if (state === "TASK_STATE_COMPLETED") metrics.tasksCompleted += 1;
   if (state === "TASK_STATE_FAILED") metrics.tasksFailed += 1;
-  return { reply, contextId: replyCtx, state };
+  return { reply, contextId: replyCtx, state, taskId };
 }
 
 // ---------------------------------------------------------------------------
@@ -496,6 +514,45 @@ export async function a2aDiscover(opts: {
   return lines.join("\n");
 }
 
+/** Resolve an agent label (configured name, URL, or discovered name) to a
+ *  peer for an outbound call. Returns an error string instead of a peer when
+ *  the label cannot be resolved. Shared by a2a_call and a2a_status. */
+function resolveCallPeer(opts: {
+  cfg: A2AConfig;
+  piDir: string;
+  agent: string;
+  /** Live discovered peers (listPeers output) — lets local/mDNS peers be called by name. */
+  discoveredPeers?: DiscoveredPeer[];
+}): { peer: Peer } | { error: string } {
+  const agent = opts.agent;
+  const known = knownLoopbackUrls(opts.cfg, opts.piDir);
+  let peer = resolvePeer(opts.cfg, agent, { knownLoopbackUrls: known });
+  if (!peer || !peer.url) {
+    // Discovered-peer name lookup (local registry / mDNS). Ambiguous names
+    // error with the candidate URLs instead of guessing a target.
+    const matches = (opts.discoveredPeers ?? []).filter((d) => d.name === agent && d.url);
+    if (matches.length > 1) {
+      return {
+        error:
+          `Error: ${matches.length} discovered peers share the name '${agent}' — ` +
+          `call by URL: ${matches.map((m) => m.url).join(", ")}`,
+      };
+    }
+    if (matches.length === 1) {
+      // ponytail: re-resolve via the URL branch so loopback-token/SSRF policy is inherited verbatim
+      peer = resolvePeer(opts.cfg, matches[0]!.url, { knownLoopbackUrls: known });
+    }
+  }
+  if (!peer || !peer.url) {
+    return {
+      error:
+        `Error: unknown agent '${agent}'. Configure it under 'a2a.peers' in ` +
+        `settings.json, pass a full http(s):// URL, or use a name from a2a_peers.`,
+    };
+  }
+  return { peer };
+}
+
 export async function a2aCall(opts: {
   cfg: A2AConfig;
   piDir: string;
@@ -504,33 +561,23 @@ export async function a2aCall(opts: {
   contextId?: string;
   /** Live discovered peers (listPeers output) — lets local/mDNS peers be called by name. */
   discoveredPeers?: DiscoveredPeer[];
+  /** Non-blocking dispatch (A2A v1.0 §3.2.2 returnImmediately): return an
+   *  ack with the task id as soon as the peer accepts the task, instead of
+   *  holding this call open until the work finishes. Long jobs keep running
+   *  on the peer no matter how long the caller waits — poll a2a_status. */
+  asyncDispatch?: boolean;
 }): Promise<string> {
   const agent = (opts.agent || "").trim();
   const message = (opts.message || "").trim();
   if (!agent || !message) return "Error: both 'agent' and 'message' are required.";
-  const known = knownLoopbackUrls(opts.cfg, opts.piDir);
-  let peer = resolvePeer(opts.cfg, agent, { knownLoopbackUrls: known });
-  if (!peer || !peer.url) {
-    // Discovered-peer name lookup (local registry / mDNS). Ambiguous names
-    // error with the candidate URLs instead of guessing a target.
-    const matches = (opts.discoveredPeers ?? []).filter((d) => d.name === agent && d.url);
-    if (matches.length > 1) {
-      return (
-        `Error: ${matches.length} discovered peers share the name '${agent}' — ` +
-        `call by URL: ${matches.map((m) => m.url).join(", ")}`
-      );
-    }
-    if (matches.length === 1) {
-      // ponytail: re-resolve via the URL branch so loopback-token/SSRF policy is inherited verbatim
-      peer = resolvePeer(opts.cfg, matches[0]!.url, { knownLoopbackUrls: known });
-    }
-  }
-  if (!peer || !peer.url) {
-    return (
-      `Error: unknown agent '${agent}'. Configure it under 'a2a.peers' in ` +
-      `settings.json, pass a full http(s):// URL, or use a name from a2a_peers.`
-    );
-  }
+  const resolved = resolveCallPeer({
+    cfg: opts.cfg,
+    piDir: opts.piDir,
+    agent,
+    discoveredPeers: opts.discoveredPeers,
+  });
+  if ("error" in resolved) return resolved.error;
+  const peer = resolved.peer;
   let result: SendResult;
   try {
     result = await sendTask({
@@ -540,12 +587,24 @@ export async function a2aCall(opts: {
       agentLabel: agent,
       message,
       contextId: opts.contextId,
+      asyncDispatch: opts.asyncDispatch,
     });
   } catch (e: any) {
     const msg = e?.message || String(e);
     if (/HTTP 401|HTTP 403/.test(msg)) return `Error: peer '${agent}' rejected auth. Check the configured token.`;
     if (/HTTP 429/.test(msg)) return `Error: peer '${agent}' rate limited us (HTTP 429). Retry later.`;
     return `Error: call to '${agent}' failed — ${msg}`;
+  }
+  // Non-blocking ack: the peer accepted the task and is running it detached
+  // from this call. (A peer that does not support returnImmediately simply
+  // blocks and returns a terminal task — fall through to normal formatting.)
+  if (opts.asyncDispatch && result.taskId && !TERMINAL_STATES.has(result.state)) {
+    return (
+      `[A2A → ${agent} · context ${result.contextId} · ${shortState(result.state)} · detached]\n` +
+      `Dispatch accepted — task ${result.taskId} is running on the peer (non-blocking). ` +
+      `This call has already returned; the peer keeps working regardless of how long it takes. ` +
+      `Poll the result with a2a_status(agent: "${agent}", task_id: "${result.taskId}").`
+    );
   }
   let header = `[A2A → ${agent} · context ${result.contextId}`;
   if (result.state) header += ` · ${shortState(result.state)}`;
@@ -557,6 +616,111 @@ export async function a2aCall(opts: {
       `with context_id '${result.contextId}'.)`;
   }
   return `${header}\n${body}`;
+}
+
+// ---------------------------------------------------------------------------
+// Task status / polling (GetTask)
+// ---------------------------------------------------------------------------
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/** Fetch one task's current state from a peer via GetTask (A2A v1.0). The
+ *  peer's per-identity task ownership applies: only the caller that created
+ *  the task can read it. */
+export async function getTask(opts: {
+  cfg: A2AConfig;
+  peer: Peer;
+  taskId: string;
+}): Promise<Task> {
+  const headers = authHeaders(opts.peer);
+  const timeout = opts.peer.timeout || opts.cfg.timeouts.send;
+  // Best-effort card fetch (to learn the rpc URL); non-fatal on failure.
+  let card: AgentCard | null = null;
+  try {
+    card = await fetchCard(opts.peer.url, headers, Math.min(timeout, 30000));
+  } catch {
+    /* tolerate */
+  }
+  const rpcBody: JsonRpcRequest = {
+    jsonrpc: "2.0",
+    id: newTaskId(),
+    method: "GetTask",
+    params: { id: opts.taskId },
+  };
+  const resp = await postJsonRpc(rpcUrl(opts.peer.url, card), rpcBody, headers, timeout);
+  if (resp.error) {
+    const err = new Error(`peer returned an error: ${resp.error.message || JSON.stringify(resp.error)}`);
+    (err as any).code = resp.error.code;
+    throw err;
+  }
+  return unwrapSendMessageResponse(resp.result ?? {}) as Task;
+}
+
+function formatTask(task: Task): string {
+  const header = `[task ${task.id} · context ${task.contextId} · ${shortState(task.status?.state ?? "")}` +
+    (task.status?.timestamp ? ` · ${task.status.timestamp}` : "") + "]";
+  // Artifacts first (final output), then status message — same precedence as
+  // replyTextFromResult.
+  let body = "";
+  if (Array.isArray(task.artifacts)) {
+    for (const a of task.artifacts) {
+      const t = extractText(a);
+      if (t) { body = t; break; }
+    }
+  }
+  if (!body && task.status?.message) body = extractText(task.status.message);
+  if (!body) body = "(no text yet — task is in progress)";
+  return `${header}\n${body}`;
+}
+
+export async function a2aStatus(opts: {
+  cfg: A2AConfig;
+  piDir: string;
+  agent: string;
+  taskId: string;
+  /** When set (seconds), poll until the task reaches a terminal state or the
+   *  deadline — polls at cfg.timeouts.async intervals (the documented "async
+   *  task poll interval"). 0/undefined = a single fetch. */
+  waitSeconds?: number;
+  discoveredPeers?: DiscoveredPeer[];
+}): Promise<string> {
+  const agent = (opts.agent || "").trim();
+  const taskId = (opts.taskId || "").trim();
+  if (!agent || !taskId) return "Error: both 'agent' and 'task_id' are required.";
+  const resolved = resolveCallPeer({
+    cfg: opts.cfg,
+    piDir: opts.piDir,
+    agent,
+    discoveredPeers: opts.discoveredPeers,
+  });
+  if ("error" in resolved) return resolved.error;
+  const peer = resolved.peer;
+  const deadline = Date.now() + Math.max(0, (opts.waitSeconds ?? 0)) * 1000;
+  const interval = Math.max(250, opts.cfg.timeouts.async);
+  for (;;) {
+    let task: Task;
+    try {
+      task = await getTask({ cfg: opts.cfg, peer, taskId });
+    } catch (e: any) {
+      if ((e as any).code === -32001) {
+        return `Error: peer '${agent}' does not know task '${taskId}' (unknown id, already evicted, or created by a different caller — tasks are visible only to the identity that sent them).`;
+      }
+      const msg = e?.message || String(e);
+      if (/HTTP 401|HTTP 403/.test(msg)) return `Error: peer '${agent}' rejected auth. Check the configured token.`;
+      return `Error: status check for '${agent}' task '${taskId}' failed — ${msg}`;
+    }
+    const state = normalizeState(task.status?.state);
+    if (TERMINAL_STATES.has(state) || !opts.waitSeconds) {
+      return formatTask(task);
+    }
+    if (Date.now() >= deadline) {
+      return (
+        formatTask(task) +
+        `\n\n(Still non-terminal after ${opts.waitSeconds}s of polling — the task keeps running on the peer; call a2a_status again later.)`
+      );
+    }
+    await sleep(Math.min(interval, Math.max(0, deadline - Date.now())));
+  }
 }
 
 /** Build the set of loopback URLs that are KNOWN peers (same-machine, same-user):

--- a/pi-a2a/extensions/lib/config-panel.ts
+++ b/pi-a2a/extensions/lib/config-panel.ts
@@ -55,6 +55,9 @@ export function buildRows(
     row("server.replyTimeoutSec", "Reply timeout (s)", "number", cfg.server.replyTimeoutSec, (v) => {
       cfg.server.replyTimeoutSec = toInt(v, cfg.server.replyTimeoutSec);
     }),
+    row("server.asyncTimeoutSec", "Async timeout (s)", "number", cfg.server.asyncTimeoutSec, (v) => {
+      cfg.server.asyncTimeoutSec = toInt(v, cfg.server.asyncTimeoutSec);
+    }),
     row("server.maxConcurrent", "Max concurrent", "number", cfg.server.maxConcurrent, (v) => {
       cfg.server.maxConcurrent = toInt(v, cfg.server.maxConcurrent);
     }),

--- a/pi-a2a/extensions/lib/config.ts
+++ b/pi-a2a/extensions/lib/config.ts
@@ -249,7 +249,7 @@ export const SECURITY_ENV_KEYS: ReadonlySet<string> = new Set([
   "A2A_ALLOW_ALL_USERS",
   "A2A_MAX_PINGPONG_TURNS",
   "A2A_RATE_LIMIT",
-"A2A_CHILD_TRANSCRIPTS",
+  "A2A_CHILD_TRANSCRIPTS",
   "A2A_CHILD_TRANSCRIPT_RETENTION_DAYS",
   // Abuse-control parity with sanitizeRepoA2ASettings ("maxConcurrent",
   // "replyTimeoutSec", "asyncTimeoutSec"): a repo must not be able to raise

--- a/pi-a2a/extensions/lib/config.ts
+++ b/pi-a2a/extensions/lib/config.ts
@@ -119,6 +119,11 @@ export interface A2AConfig {
     workspace: string;
     maxConcurrent: number;
     replyTimeoutSec: number;
+    /** Supervision window for detached (returnImmediately) tasks, in seconds.
+     *  The caller's HTTP request already returned an ACK, so the reply window
+     *  does not apply — this bounds a detached run instead. 0 = unbounded
+     *  (caller-supervised via GetTask / CancelTask). */
+    asyncTimeoutSec: number;
     agentName: string;
     publicUrl: string;
     sharedToken: string;
@@ -174,6 +179,7 @@ const DEFAULTS: A2AConfig = {
     workspace: "",
     maxConcurrent: 3,
     replyTimeoutSec: 300,
+    asyncTimeoutSec: 86400,
     agentName: "",
     publicUrl: "",
     sharedToken: "",
@@ -276,6 +282,7 @@ export function loadEnv(cwd: string): Record<string, string> {
       /* ignore */
     }
   }
+  const paths = envCandidates(cwd).reverse();
   // Walk from filesystem root up to cwd so cwd wins — but NEVER let a
   // repo-controlled .env.local set security-relevant keys (a coding agent
   // opens attacker-controlled repos; those files must not be able to enable
@@ -284,7 +291,6 @@ export function loadEnv(cwd: string): Record<string, string> {
   // that re-parse is deliberately NOT skipped — its security keys were already
   // merged above and delete-from-copy here cannot remove them. Keep the global
   // read FIRST: it is the only place repo keys could ever be overridden back.
-  const paths = envCandidates(cwd).reverse();
   for (const p of paths) {
     try {
       const parsed = parseDotEnv(readFileSync(p, "utf-8"));
@@ -332,6 +338,7 @@ function sanitizeRepoA2ASettings(s: any): any {
       // keep-forever disk-fill when raised).
       "childTranscripts",
       "childTranscriptRetentionDays",
+      "asyncTimeoutSec",
     ])
       delete srv[k];
     c.server = srv;
@@ -452,6 +459,7 @@ export function loadConfig(opts: {
   cfg.server.workspace = String(srv.workspace ?? "");
   cfg.server.maxConcurrent = num(srv.maxConcurrent, DEFAULTS.server.maxConcurrent);
   cfg.server.replyTimeoutSec = num(srv.replyTimeoutSec ?? env.A2A_REPLY_TIMEOUT, DEFAULTS.server.replyTimeoutSec);
+  cfg.server.asyncTimeoutSec = num(srv.asyncTimeoutSec ?? env.A2A_ASYNC_TIMEOUT, DEFAULTS.server.asyncTimeoutSec);
   cfg.server.agentName = String(srv.agentName ?? env.A2A_AGENT_NAME ?? "");
   cfg.server.publicUrl = String(srv.publicUrl ?? env.A2A_PUBLIC_URL ?? "");
   cfg.server.sharedToken = String(srv.sharedToken ?? env.A2A_BEARER_TOKEN ?? "");

--- a/pi-a2a/extensions/lib/config.ts
+++ b/pi-a2a/extensions/lib/config.ts
@@ -118,6 +118,10 @@ export interface A2AConfig {
     host: string;
     workspace: string;
     maxConcurrent: number;
+    /** Blocking-send supervision window in seconds — the HTTP request stays
+     *  open at most this long. 0 = no reply-window timer (unbounded): the
+     *  request stays open until the run settles. Deliberate, rare — same 0
+     *  semantics as asyncTimeoutSec. */
     replyTimeoutSec: number;
     /** Supervision window for detached (returnImmediately) tasks, in seconds.
      *  The caller's HTTP request already returned an ACK, so the reply window
@@ -231,8 +235,12 @@ function parseDotEnv(text: string): Record<string, string> {
  * cwd→root `.env.local` walk: a coding agent opens attacker-controlled repos,
  * so repo files must not be able to enable the server, widen the bind,
  * install tokens, or redirect the gateway (see loadEnv).
+ *
+ * Exported for the env/settings parity test: the set must cover the same
+ * server abuse-control surface that sanitizeRepoA2ASettings strips from
+ * repo-controlled settings.json.
  */
-const SECURITY_ENV_KEYS: ReadonlySet<string> = new Set([
+export const SECURITY_ENV_KEYS: ReadonlySet<string> = new Set([
   "A2A_SERVER_ENABLED",
   "A2A_HOST",
   "A2A_BEARER_TOKEN",
@@ -241,8 +249,16 @@ const SECURITY_ENV_KEYS: ReadonlySet<string> = new Set([
   "A2A_ALLOW_ALL_USERS",
   "A2A_MAX_PINGPONG_TURNS",
   "A2A_RATE_LIMIT",
-  "A2A_CHILD_TRANSCRIPTS",
+"A2A_CHILD_TRANSCRIPTS",
   "A2A_CHILD_TRANSCRIPT_RETENTION_DAYS",
+  // Abuse-control parity with sanitizeRepoA2ASettings ("maxConcurrent",
+  // "replyTimeoutSec", "asyncTimeoutSec"): a repo must not be able to raise
+  // the concurrency ceiling or stretch either supervision window
+  // (asyncTimeoutSec 0 = unbounded; a huge window pins maxConcurrent slots
+  // for the whole window).
+  "A2A_MAX_CONCURRENT",
+  "A2A_REPLY_TIMEOUT",
+  "A2A_ASYNC_TIMEOUT",
   "A2A_VERIFY_SSL",
   "A2A_DISCOVERY_MDNS",
   "A2A_ENRICH_CARD",
@@ -282,7 +298,6 @@ export function loadEnv(cwd: string): Record<string, string> {
       /* ignore */
     }
   }
-  const paths = envCandidates(cwd).reverse();
   // Walk from filesystem root up to cwd so cwd wins — but NEVER let a
   // repo-controlled .env.local set security-relevant keys (a coding agent
   // opens attacker-controlled repos; those files must not be able to enable
@@ -291,6 +306,7 @@ export function loadEnv(cwd: string): Record<string, string> {
   // that re-parse is deliberately NOT skipped — its security keys were already
   // merged above and delete-from-copy here cannot remove them. Keep the global
   // read FIRST: it is the only place repo keys could ever be overridden back.
+  const paths = envCandidates(cwd).reverse();
   for (const p of paths) {
     try {
       const parsed = parseDotEnv(readFileSync(p, "utf-8"));

--- a/pi-a2a/extensions/lib/server.ts
+++ b/pi-a2a/extensions/lib/server.ts
@@ -959,7 +959,36 @@ export class A2AServer {
     // session is no longer bounded by the caller's reply window (detached
     // runs are supervised by server.asyncTimeoutSec instead).
     const execution = this.executeTask(st, identity, inboundText, returnImmediately);
-    if (returnImmediately) return st.task;
+    if (returnImmediately) {
+      // The detached run continues after this reply returns; nothing else
+      // will ever await `execution`. executeTask never rejects by contract
+      // (every failure is classified into the task state), but that is
+      // discipline, not a type guarantee — a throw on a path outside its
+      // try/catch (a store update, an activity callback, an OOM) would be an
+      // UNOBSERVED rejection that takes the process down (Node's default).
+      // Observe the promise and contain an unexpected throw: best-effort
+      // mark the task FAILED (redacted) so a poller sees the truth instead
+      // of WORKING forever, and never rethrow — this catch is the last
+      // observer of the promise.
+      execution.catch((e) => {
+        try {
+          if (!st.done) {
+            this.store.update(taskId, (t) => {
+              t.status.state = STATE_FAILED;
+              t.status.message = {
+                role: "ROLE_AGENT",
+                parts: [{ text: redactOutbound(`internal error: ${e?.message ?? String(e)}`), mediaType: "text/plain" }],
+                messageId: newContextId(),
+              };
+            });
+            st.done = true;
+          }
+        } catch {
+          /* containment is best-effort */
+        }
+      });
+      return st.task;
+    }
     return execution;
   }
 
@@ -984,23 +1013,34 @@ export class A2AServer {
     // after the suite/server is done (the runner rejects, no abort fires,
     // nothing clears it: with the 86400s async default that is a full day).
     let timer: ReturnType<typeof setTimeout> | undefined;
+    // Local ground truth for "this run was killed by OUR supervision timer",
+    // set in the timer callback BEFORE the abort so it can never disagree
+    // with the timer. The catch path keys the supervision classification on
+    // this flag, never on the abort reason's TEXT — prefix-matching
+    // "reply timeout" would let any future abort site (or runner error) with
+    // that wording masquerade as a supervision kill.
+    let timedOut = false;
     try {
       // Blocking runs are bounded by the reply window (the HTTP request is
       // holding the caller hostage). Detached runs are bounded by the async
-      // window instead — 0 disables the timer entirely (caller-supervised).
+      // window instead. 0 disables the timer for BOTH windows, documented as
+      // "unbounded / caller-supervised": for the async window that is the
+      // deliberate submit-and-poll contract, and for the reply window it
+      // replaces the pre-async-dispatch degenerate reading of
+      // setTimeout(…, 0) — "instant timeout on every task" — which no
+      // working configuration can have depended on.
       const timeoutSec = detached ? this.cfg.server.asyncTimeoutSec : this.cfg.server.replyTimeoutSec;
       if (timeoutSec > 0) {
-        timer = setTimeout(
-          () =>
-            controller.abort(
-              new Error(
-                detached
-                  ? `async timeout: exceeded the ${timeoutSec}s detached-task window — session aborted mid-run, result is truncated`
-                  : "reply timeout",
-              ),
+        timer = setTimeout(() => {
+          timedOut = true;
+          controller.abort(
+            new Error(
+              detached
+                ? `async timeout: exceeded the ${timeoutSec}s detached-task window — session aborted mid-run, result is truncated`
+                : "reply timeout",
             ),
-          timeoutSec * 1000,
-        );
+          );
+        }, timeoutSec * 1000);
         // Clear on abort too: a runner that ignores its signal and never
         // settles must not hold the process alive until the timer fires.
         controller.signal.addEventListener("abort", () => clearTimeout(timer), { once: true });
@@ -1058,19 +1098,17 @@ export class A2AServer {
       const aborted = controller.signal.aborted;
       // Distinguish user-initiated cancel (CANCELED) from system timeout/failure (FAILED).
       const state = aborted && st.userCanceled ? STATE_CANCELED : STATE_FAILED;
-      this.auditTranscript(taskId, identity, (e as any)?.transcriptPath, (e as any)?.stepCount);
-      // A supervision timeout's ground truth is the abort REASON (it carries
-      // the descriptive "reply/async timeout: exceeded the Ns window …"
-      // text), not whatever error the runner happened to throw when the
-      // abort landed — a runner may reject with its own error and lose the
-      // classification. Prefer the reason only for our own timeout aborts:
-      // client-disconnect aborts carry a generic AbortError, and cancels are
-      // classified above.
+this.auditTranscript(taskId, identity, (e as any)?.transcriptPath, (e as any)?.stepCount);
+      // A supervision timeout's ground truth is the local `timedOut` flag
+      // (set by OUR timer callback), never the abort reason's TEXT — the
+      // reason carries the descriptive "reply/async timeout: … the Ns window"
+      // message we abort with, and a runner rejecting with its own error
+      // must not be able to spoof that wording into a supervision
+      // classification. Client-disconnect aborts carry a generic AbortError,
+      // and cancels are classified above (userCanceled). timedOut implies
+      // aborted — the flag is set only in the callback that aborts.
       const reason = controller.signal.reason;
-      const reasonMsg =
-        aborted && !st.userCanceled && reason instanceof Error && /^(reply|async) timeout/.test(reason.message)
-          ? reason.message
-          : undefined;
+      const reasonMsg = timedOut && !st.userCanceled && reason instanceof Error ? reason.message : undefined;
       this.store.update(taskId, (t) => {
         // Don't clobber a cancel-handler-set CANCELED state with an error message.
         t.status.state = state;
@@ -1106,7 +1144,6 @@ export class A2AServer {
       }
       return st.task;
     } finally {
-      if (replyTimer !== undefined) clearTimeout(replyTimer);
       this.running -= 1;
       // The run settled (completed or classified) — the supervision timer's
       // job is done. Without this, a FAILED run whose runner threw its own

--- a/pi-a2a/extensions/lib/server.ts
+++ b/pi-a2a/extensions/lib/server.ts
@@ -131,6 +131,19 @@ class TaskStore {
 }
 
 // ---------------------------------------------------------------------------
+// Non-blocking send detection (A2A v1.0 §3.2.2 SendMessageConfiguration)
+// ---------------------------------------------------------------------------
+
+/** True when the caller asked for an immediate in-progress Task ack instead
+ *  of waiting for the terminal state (submit-and-poll). Accepts the
+ *  snake_case spelling some early clients send. */
+function wantsImmediateReturn(params: any): boolean {
+  const cfg = params?.configuration;
+  if (!cfg || typeof cfg !== "object") return false;
+  return cfg.returnImmediately === true || cfg.return_immediately === true;
+}
+
+// ---------------------------------------------------------------------------
 // Rate limiter (sliding window per identity; prunes stale entries)
 // ---------------------------------------------------------------------------
 
@@ -907,6 +920,10 @@ export class A2AServer {
     const inboundText = extractText(params);
     const contextId = String(params.contextId || msg.contextId || newContextId());
     const taskId = newTaskId();
+    // A2A v1.0 §3.2.2 SendMessageConfiguration.returnImmediately — the caller
+    // asks for an immediate in-progress Task instead of waiting for the
+    // terminal state (submit-and-poll).
+    const returnImmediately = wantsImmediateReturn(params);
 
     // Anti-loop: cap per-context turns.
     if (!this.antiLoop.record(contextId)) {
@@ -934,25 +951,60 @@ export class A2AServer {
     }
 
     this.running += 1;
+
+    // Blocking (default): await the run and return the terminal Task.
+    // Non-blocking (returnImmediately): return the in-progress Task as an
+    // ACK right away and let the run continue detached from the HTTP request
+    // — the caller polls GetTask / subscribes / cancels by task id, and the
+    // session is no longer bounded by the caller's reply window (detached
+    // runs are supervised by server.asyncTimeoutSec instead).
+    const execution = this.executeTask(st, identity, inboundText, returnImmediately);
+    if (returnImmediately) return st.task;
+    return execution;
+  }
+
+  /**
+   * Run one stored task to completion and update the store. Never rejects —
+   * failures are classified into the task state (FAILED/CANCELED) exactly as
+   * the blocking path has always done. `this.running` is held for the whole
+   * execution, so detached runs still count against server.maxConcurrent.
+   */
+  private async executeTask(
+    st: StoredTask,
+    identity: string,
+    inboundText: string,
+    detached: boolean,
+  ): Promise<any> {
+    const taskId = st.task.id;
+    const controller = st.controller!;
     const startedAt = Date.now();
-    // Reply-window watchdog. Cleared in the finally below on EVERY exit path:
-    // a runner that throws skips any inline clearTimeout and never aborts the
-    // controller, so without this the timer stayed armed for the full reply
-    // window (default 300s) — the task reported FAILED while the timer kept
-    // the event loop alive (test-suite exit-hang, fleet task #257).
-    let replyTimer: ReturnType<typeof setTimeout> | undefined;
+    // Supervision timer for this run: reply window (blocking) or async window
+    // (detached). Hoisted so the finally can clear it on EVERY settle path —
+    // a timer left armed after a failed run keeps the process alive long
+    // after the suite/server is done (the runner rejects, no abort fires,
+    // nothing clears it: with the 86400s async default that is a full day).
+    let timer: ReturnType<typeof setTimeout> | undefined;
     try {
-      const timeoutMs = this.cfg.server.replyTimeoutSec * 1000;
-      replyTimer = setTimeout(
-        () =>
-          controller.abort(
-            new Error(
-              `reply timeout: exceeded the ${this.cfg.server.replyTimeoutSec}s reply window — session aborted mid-run, reply is truncated`,
+      // Blocking runs are bounded by the reply window (the HTTP request is
+      // holding the caller hostage). Detached runs are bounded by the async
+      // window instead — 0 disables the timer entirely (caller-supervised).
+      const timeoutSec = detached ? this.cfg.server.asyncTimeoutSec : this.cfg.server.replyTimeoutSec;
+      if (timeoutSec > 0) {
+        timer = setTimeout(
+          () =>
+            controller.abort(
+              new Error(
+                detached
+                  ? `async timeout: exceeded the ${timeoutSec}s detached-task window — session aborted mid-run, result is truncated`
+                  : "reply timeout",
+              ),
             ),
-          ),
-        timeoutMs,
-      );
-      controller.signal.addEventListener("abort", () => clearTimeout(replyTimer), { once: true });
+          timeoutSec * 1000,
+        );
+        // Clear on abort too: a runner that ignores its signal and never
+        // settles must not hold the process alive until the timer fires.
+        controller.signal.addEventListener("abort", () => clearTimeout(timer), { once: true });
+      }
       const wrapped = wrapInbound(identity, inboundText);
       const runner = this.requireRunner();
       const out = await runner({
@@ -1007,6 +1059,18 @@ export class A2AServer {
       // Distinguish user-initiated cancel (CANCELED) from system timeout/failure (FAILED).
       const state = aborted && st.userCanceled ? STATE_CANCELED : STATE_FAILED;
       this.auditTranscript(taskId, identity, (e as any)?.transcriptPath, (e as any)?.stepCount);
+      // A supervision timeout's ground truth is the abort REASON (it carries
+      // the descriptive "reply/async timeout: exceeded the Ns window …"
+      // text), not whatever error the runner happened to throw when the
+      // abort landed — a runner may reject with its own error and lose the
+      // classification. Prefer the reason only for our own timeout aborts:
+      // client-disconnect aborts carry a generic AbortError, and cancels are
+      // classified above.
+      const reason = controller.signal.reason;
+      const reasonMsg =
+        aborted && !st.userCanceled && reason instanceof Error && /^(reply|async) timeout/.test(reason.message)
+          ? reason.message
+          : undefined;
       this.store.update(taskId, (t) => {
         // Don't clobber a cancel-handler-set CANCELED state with an error message.
         t.status.state = state;
@@ -1016,7 +1080,7 @@ export class A2AServer {
             // Redacted: error messages can embed reply text (parse failures,
             // tool errors quoting the payload) — same outbound trust boundary
             // as the reply artifact.
-            parts: [{ text: redactOutbound(e?.message || String(e)), mediaType: "text/plain" }],
+            parts: [{ text: redactOutbound(reasonMsg ?? e?.message ?? String(e)), mediaType: "text/plain" }],
             messageId: newContextId(),
           };
         }
@@ -1044,6 +1108,11 @@ export class A2AServer {
     } finally {
       if (replyTimer !== undefined) clearTimeout(replyTimer);
       this.running -= 1;
+      // The run settled (completed or classified) — the supervision timer's
+      // job is done. Without this, a FAILED run whose runner threw its own
+      // error (no abort → no listener fire) leaked an armed timer that kept
+      // the process alive after the suite finished.
+      clearTimeout(timer);
     }
   }
 
@@ -1094,6 +1163,15 @@ export class A2AServer {
     // runner's session stops instead of burning tokens nobody will read.
     const disconnect = new AbortController();
     res.on("close", () => disconnect.abort());
+
+    // return_immediately has no effect on streaming operations (A2A v1.0
+    // §3.2.2) — strip it so the stream path keeps its blocking semantics.
+    if (wantsImmediateReturn(params)) {
+      params = {
+        ...params,
+        configuration: { ...(params.configuration ?? {}), returnImmediately: false, return_immediately: false },
+      };
+    }
 
     this.messageSend(params, identity, disconnect.signal)
       .then((task) => {

--- a/pi-a2a/extensions/lib/server.ts
+++ b/pi-a2a/extensions/lib/server.ts
@@ -1098,7 +1098,7 @@ export class A2AServer {
       const aborted = controller.signal.aborted;
       // Distinguish user-initiated cancel (CANCELED) from system timeout/failure (FAILED).
       const state = aborted && st.userCanceled ? STATE_CANCELED : STATE_FAILED;
-this.auditTranscript(taskId, identity, (e as any)?.transcriptPath, (e as any)?.stepCount);
+      this.auditTranscript(taskId, identity, (e as any)?.transcriptPath, (e as any)?.stepCount);
       // A supervision timeout's ground truth is the local `timedOut` flag
       // (set by OUR timer callback), never the abort reason's TEXT — the
       // reason carries the descriptive "reply/async timeout: … the Ns window"

--- a/pi-a2a/extensions/test/client.test.ts
+++ b/pi-a2a/extensions/test/client.test.ts
@@ -7,11 +7,12 @@ import {
   a2aDiscover,
   a2aList,
   a2aOrchestrate,
+  a2aStatus,
   isPrivateHost,
   metrics,
   rpcUrl,
 } from "../lib/client";
-import { buildAgentCard, STATE_COMPLETED } from "../lib/protocol";
+import { buildAgentCard, STATE_COMPLETED, STATE_WORKING } from "../lib/protocol";
 import { setGatewayRegistrationName, setGatewayPeers, gatewayKeyFromUrl } from "../lib/config";
 import type { DiscoveredPeer } from "../lib/discovery";
 
@@ -360,6 +361,234 @@ describe("client", () => {
       await a2aCall({ cfg, piDir, agent: "bob", message: "my key is sk-1234567890abcdefXX" });
       assert.notInclude(capturedBody, "sk-1234567890abcdefXX");
       assert.include(capturedBody, "sk-[redacted]");
+    });
+  });
+
+  describe("non-blocking dispatch (asyncDispatch + a2a_status)", () => {
+    const workingTask = {
+      id: "task-9",
+      contextId: "ctx-async",
+      status: { state: STATE_WORKING },
+    };
+    const completedTask = {
+      id: "task-9",
+      contextId: "ctx-async",
+      status: { state: STATE_COMPLETED },
+      artifacts: [{ parts: [{ text: "late result" }] }],
+    };
+
+    /** Sequential POST-result mock: each POST returns the next entry (last
+     *  one repeats). GETs (card fetch) 404 — non-fatal, rpcUrl falls back to
+     *  the base URL. */
+    function seqMock(results: any[]): { fetch: FetchMock; posts: () => number } {
+      let i = 0;
+      let n = 0;
+      const fetch = async (url: string, init?: any) => {
+        if (init?.method === "POST") {
+          n += 1;
+          const result = results[Math.min(i++, results.length - 1)];
+          return makeResp({ jsonrpc: "2.0", id: 1, result }, 200);
+        }
+        return makeResp(null, 404);
+      };
+      return { fetch, posts: () => n };
+    }
+
+    it("sends configuration.returnImmediately only when asyncDispatch is set", async () => {
+      const bodies: any[] = [];
+      globalThis.fetch = (async (_url: string, init?: any) => {
+        if (init?.method === "POST") bodies.push(JSON.parse(init.body));
+        return makeResp({ jsonrpc: "2.0", id: 1, result: { task: workingTask } }, 200);
+      }) as any;
+      const cfg = DEFAULTS();
+      cfg.peers.bob = { url: "http://b", auth: { type: "none" }, timeout: 5000, capabilities: [] };
+      await a2aCall({ cfg, piDir, agent: "bob", message: "hi", asyncDispatch: true });
+      await a2aCall({ cfg, piDir, agent: "bob", message: "hi" });
+      assert.equal(bodies[0]!.params.configuration?.returnImmediately, true, "asyncDispatch must set the configuration");
+      assert.isUndefined(bodies[1]!.params.configuration, "a blocking call must not send any configuration");
+    });
+
+    it("formats the detached ack with the poll hint", async () => {
+      globalThis.fetch = mockFetch({ rpcResult: { task: workingTask } }) as any;
+      const cfg = DEFAULTS();
+      cfg.peers.bob = { url: "http://b", auth: { type: "none" }, timeout: 5000, capabilities: [] };
+      const out = await a2aCall({ cfg, piDir, agent: "bob", message: "hi", asyncDispatch: true });
+      assert.include(out, "detached");
+      assert.include(out, "task-9");
+      assert.include(out, "non-blocking");
+      assert.include(out, 'a2a_status(agent: "bob", task_id: "task-9")');
+      assert.notInclude(out, "late result");
+    });
+
+    it("falls through to normal formatting when the task finished before the ack", async () => {
+      // A fast peer completes before the ack is serialized — the ack carries
+      // the terminal state, so the caller gets the result inline, no poll hint.
+      globalThis.fetch = mockFetch({ rpcResult: { task: completedTask } }) as any;
+      const cfg = DEFAULTS();
+      cfg.peers.bob = { url: "http://b", auth: { type: "none" }, timeout: 5000, capabilities: [] };
+      const out = await a2aCall({ cfg, piDir, agent: "bob", message: "hi", asyncDispatch: true });
+      assert.include(out, "completed");
+      assert.include(out, "late result");
+      assert.notInclude(out, "detached");
+      assert.notInclude(out, "a2a_status(");
+    });
+
+    it("persists the dispatch ack marker under the conversation context", async () => {
+      const { loadConversation } = await import("../lib/persistence");
+      globalThis.fetch = mockFetch({ rpcResult: { task: workingTask } }) as any;
+      const cfg = DEFAULTS();
+      cfg.peers.bob = { url: "http://b", auth: { type: "none" }, timeout: 5000, capabilities: [] };
+      await a2aCall({ cfg, piDir, agent: "bob", message: "hi", asyncDispatch: true });
+      // Both sides land under the PEER's context id so a2a_history works.
+      const msgs = loadConversation(piDir, "ctx-async");
+      assert.lengthOf(msgs, 2);
+      assert.equal(msgs[0]!.role, "user");
+      assert.equal(msgs[1]!.role, "agent");
+      assert.include(msgs[1]!.text, "dispatched non-blocking");
+      assert.include(msgs[1]!.text, "task-9");
+    });
+
+    it("a2a_status: single fetch without wait_seconds", async () => {
+      const m = seqMock([{ task: workingTask }]);
+      globalThis.fetch = m.fetch as any;
+      const cfg = DEFAULTS();
+      cfg.peers.bob = { url: "http://b", auth: { type: "none" }, timeout: 5000, capabilities: [] };
+      const out = await a2aStatus({ cfg, piDir, agent: "bob", taskId: "task-9" });
+      assert.equal(m.posts(), 1, "no wait_seconds → exactly one GetTask");
+      assert.include(out, "task-9");
+      assert.include(out, "working");
+      assert.include(out, "no text yet");
+    });
+
+    it("a2a_status: polls to terminal with wait_seconds", async () => {
+      const m = seqMock([{ task: workingTask }, { task: completedTask }]);
+      globalThis.fetch = m.fetch as any;
+      const cfg = DEFAULTS();
+      cfg.timeouts.async = 250; // min poll interval for a fast test
+      cfg.peers.bob = { url: "http://b", auth: { type: "none" }, timeout: 5000, capabilities: [] };
+      const out = await a2aStatus({ cfg, piDir, agent: "bob", taskId: "task-9", waitSeconds: 5 });
+      assert.equal(m.posts(), 2, "WORKING then COMPLETED → exactly two GetTask polls");
+      assert.include(out, "completed");
+      assert.include(out, "late result");
+    });
+
+    it("a2a_status: expires with a clear message at the deadline", async () => {
+      const m = seqMock([{ task: workingTask }]);
+      globalThis.fetch = m.fetch as any;
+      const cfg = DEFAULTS();
+      cfg.timeouts.async = 250;
+      cfg.peers.bob = { url: "http://b", auth: { type: "none" }, timeout: 5000, capabilities: [] };
+      const out = await a2aStatus({ cfg, piDir, agent: "bob", taskId: "task-9", waitSeconds: 0.3 });
+      assert.include(out, "Still non-terminal after 0.3s of polling");
+      assert.include(out, "call a2a_status again later");
+    });
+
+    it("a2a_status: non-positive wait_seconds is a single fetch (no nonsense deadline)", async () => {
+      const m = seqMock([{ task: workingTask }]);
+      globalThis.fetch = m.fetch as any;
+      const cfg = DEFAULTS();
+      cfg.timeouts.async = 250;
+      cfg.peers.bob = { url: "http://b", auth: { type: "none" }, timeout: 5000, capabilities: [] };
+      const out = await a2aStatus({ cfg, piDir, agent: "bob", taskId: "task-9", waitSeconds: -5 });
+      assert.equal(m.posts(), 1, "negative wait_seconds must not enter the poll loop");
+      assert.notInclude(out, "-5s");
+      assert.include(out, "working");
+    });
+
+    it("a2a_status: maps TaskNotFoundError (-32001) to the unknown/evicted/foreign hint", async () => {
+      globalThis.fetch = mockFetch({ rpcError: { code: -32001, message: "task not found" } }) as any;
+      const cfg = DEFAULTS();
+      cfg.peers.bob = { url: "http://b", auth: { type: "none" }, timeout: 5000, capabilities: [] };
+      const out = await a2aStatus({ cfg, piDir, agent: "bob", taskId: "task-ghost" });
+      assert.include(out, "does not know task 'task-ghost'");
+      assert.include(out, "visible only to the identity that sent them");
+    });
+
+    it("a2a_status: maps 401 to the auth error", async () => {
+      globalThis.fetch = mockFetch({ rpcStatus: 401 }) as any;
+      const cfg = DEFAULTS();
+      cfg.peers.bob = { url: "http://b", auth: { type: "none" }, timeout: 5000, capabilities: [] };
+      const out = await a2aStatus({ cfg, piDir, agent: "bob", taskId: "task-9" });
+      assert.include(out, "rejected auth");
+    });
+
+    it("a2a_status: errors with candidate URLs for an ambiguous discovered name", async () => {
+      const discoveredPeers: DiscoveredPeer[] = [
+        { name: "pi-s2", url: "http://127.0.0.1:9912", source: "local", alive: true },
+        { name: "pi-s2", url: "http://127.0.0.1:9913", source: "local", alive: true },
+      ];
+      const out = await a2aStatus({ cfg: DEFAULTS(), piDir, agent: "pi-s2", taskId: "task-9", discoveredPeers });
+      assert.include(out, "share the name 'pi-s2'");
+      assert.include(out, "9912");
+      assert.include(out, "9913");
+    });
+
+    it("a2a_status: cancels promptly when the abort signal fires mid-poll", async () => {
+      const m = seqMock([{ task: workingTask }]);
+      globalThis.fetch = m.fetch as any;
+      const cfg = DEFAULTS();
+      cfg.timeouts.async = 250;
+      cfg.peers.bob = { url: "http://b", auth: { type: "none" }, timeout: 5000, capabilities: [] };
+      const ctl = new AbortController();
+      setTimeout(() => ctl.abort(), 120);
+      const t0 = Date.now();
+      const out = await a2aStatus({
+        cfg,
+        piDir,
+        agent: "bob",
+        taskId: "task-9",
+        waitSeconds: 30, // would poll ~2min at 250ms without the signal
+        signal: ctl.signal,
+      });
+      const elapsed = Date.now() - t0;
+      assert.isBelow(elapsed, 2000, `abort must end the poll promptly (took ${elapsed}ms)`);
+      assert.include(out, "Status polling canceled");
+      assert.include(out, "call a2a_status");
+      // The last-known state is still reported — the abort only stops polling.
+      assert.include(out, "working");
+    });
+
+    it("a2a_status: returns immediately on a pre-aborted signal (no fetch)", async () => {
+      const m = seqMock([{ task: workingTask }]);
+      globalThis.fetch = m.fetch as any;
+      const cfg = DEFAULTS();
+      cfg.peers.bob = { url: "http://b", auth: { type: "none" }, timeout: 5000, capabilities: [] };
+      const ctl = new AbortController();
+      ctl.abort();
+      const out = await a2aStatus({
+        cfg,
+        piDir,
+        agent: "bob",
+        taskId: "task-9",
+        waitSeconds: 30,
+        signal: ctl.signal,
+      });
+      assert.equal(m.posts(), 0, "a pre-aborted poll must not fetch at all");
+      assert.include(out, "Status polling canceled");
+      assert.include(out, "task-9");
+    });
+
+    it("carries X-A2A-Identity on SendMessage AND on GetTask polls", async () => {
+      const seen: Array<Record<string, string>> = [];
+      globalThis.fetch = (async (url: string, init?: any) => {
+        if (init?.method === "POST") {
+          seen.push({ ...(init?.headers || {}) });
+          const isGetTask = JSON.parse(init.body).method === "GetTask";
+          return makeResp(
+            { jsonrpc: "2.0", id: 1, result: { task: isGetTask ? completedTask : workingTask } },
+            200,
+          );
+        }
+        return makeResp(null, 404);
+      }) as any;
+      const cfg = DEFAULTS();
+      cfg.selfIdentity = "pi-kimchi";
+      cfg.peers.bob = { url: "http://b", auth: { type: "none" }, timeout: 5000, capabilities: [] };
+      await a2aCall({ cfg, piDir, agent: "bob", message: "hi", asyncDispatch: true });
+      await a2aStatus({ cfg, piDir, agent: "bob", taskId: "task-9" });
+      assert.equal(seen.length, 2, "one SendMessage + one GetTask");
+      assert.equal(seen[0]!["X-A2A-Identity"], "pi-kimchi", "SendMessage carries the identity");
+      assert.equal(seen[1]!["X-A2A-Identity"], "pi-kimchi", "GetTask polls carry the identity too");
     });
   });
 

--- a/pi-a2a/extensions/test/config-panel.test.ts
+++ b/pi-a2a/extensions/test/config-panel.test.ts
@@ -370,7 +370,7 @@ describe("config-panel", () => {
       // appears must be followed by ALL of its rows before the next header
       // or the footer — i.e. no split group with a detached header.
       const expected: Record<string, number> = {
-        SERVER: 10, DISCOVERY: 6, GATEWAY: 7, IDENTITY: 1, PEERS: 1, UI: 1,
+        SERVER: 11, DISCOVERY: 6, GATEWAY: 7, IDENTITY: 1, PEERS: 1, UI: 1,
       };
       const steps = 8; // render + scroll several times to hit every window
       for (let step = 0; step < steps; step++) {
@@ -399,15 +399,35 @@ describe("config-panel", () => {
       }
     });
 
-    it("initial view shows SERVER + DISCOVERY together (no split)", () => {
+    it("initial view shows SERVER whole; DISCOVERY follows whole (no split)", () => {
+      // Since asyncTimeoutSec joined the SERVER group (#340), SERVER is 12
+      // lines (header + 11 rows) and SERVER+DISCOVERY no longer fit the panel
+      // kernel's 18-row budget together — screen 1 is SERVER alone, and the
+      // next scroll step brings DISCOVERY whole. The property under test is
+      // the 0.5.1 invariant: whole groups only, never a split group.
       const cfg = DEFAULTS();
       const model = new ConfigPanelModel(buildRows(cfg), null);
       const out = model.render(80).join("\n");
       assert.ok(out.includes("SERVER"), "SERVER header present");
-      assert.ok(out.includes("DISCOVERY"), "DISCOVERY header present on first screen");
+      // Every SERVER row is on screen (group not truncated mid-way).
+      for (const label of [
+        "Server enabled", "Port", "Port fallback", "Bind host", "Agent name",
+        "Reply timeout (s)", "Async timeout (s)", "Max concurrent",
+        "Allow all users", "Max ping-pong turns", "Rate limit /min",
+      ]) {
+        assert.ok(out.includes(label), `SERVER row '${label}' visible on first screen`);
+      }
+      // Navigate until the window slides to DISCOVERY (the window follows the
+      // selection; it slides once the cursor leaves the SERVER group).
+      let out2 = "";
+      for (let i = 0; i < 40 && !out2.includes("DISCOVERY"); i++) {
+        model.handleInput("\u001b[B");
+        out2 = model.render(80).join("\n");
+      }
+      assert.ok(out2.includes("DISCOVERY"), "DISCOVERY header reachable by scrolling");
       // Every discovery row is on screen (group not truncated mid-way).
       for (const label of ["Local registry", "Heartbeat (s)", "Registry TTL (s)", "mDNS broadcast", "mDNS service type", "Enrich Agent Card"]) {
-        assert.ok(out.includes(label), `DISCOVERY row '${label}' visible on first screen`);
+        assert.ok(out2.includes(label), `DISCOVERY row '${label}' visible on the next screen`);
       }
     });
   });

--- a/pi-a2a/extensions/test/config.test.ts
+++ b/pi-a2a/extensions/test/config.test.ts
@@ -114,7 +114,7 @@ describe("config", () => {
       assert.isTrue(cfg.verifySsl, "verifySsl must not be disabled by repo .env.local");
       assert.equal(cfg.server.rateLimitPerMin, DEFAULTS().server.rateLimitPerMin, "rate limit must not be neutered by repo .env.local");
       assert.equal(cfg.server.maxPingpongTurns, DEFAULTS().server.maxPingpongTurns, "anti-loop cap must not be raised by repo .env.local");
-assert.isTrue(cfg.server.childTranscripts, "childTranscripts must not be disabled by repo .env.local");
+      assert.isTrue(cfg.server.childTranscripts, "childTranscripts must not be disabled by repo .env.local");
       assert.equal(cfg.server.childTranscriptRetentionDays, DEFAULTS().server.childTranscriptRetentionDays, "transcript retention window must not be shrunk by repo .env.local");
       assert.equal(cfg.server.maxConcurrent, DEFAULTS().server.maxConcurrent, "concurrency cap must not be raised by repo .env.local");
       assert.equal(cfg.server.replyTimeoutSec, DEFAULTS().server.replyTimeoutSec, "reply window must not be stretched by repo .env.local");
@@ -239,7 +239,7 @@ childTranscripts: false,
       assert.equal(cfg.server.rateLimitPerMin, DEFAULTS().server.rateLimitPerMin, "rate limit must not be neutered by repo settings.json");
       assert.equal(cfg.server.maxConcurrent, DEFAULTS().server.maxConcurrent, "concurrency cap must not be raised by repo settings.json");
       assert.equal(cfg.server.maxPingpongTurns, DEFAULTS().server.maxPingpongTurns, "anti-loop cap must not be raised by repo settings.json");
-assert.isTrue(cfg.server.childTranscripts, "childTranscripts must not be disabled by repo settings.json");
+      assert.isTrue(cfg.server.childTranscripts, "childTranscripts must not be disabled by repo settings.json");
       assert.equal(cfg.server.childTranscriptRetentionDays, DEFAULTS().server.childTranscriptRetentionDays, "transcript retention window must not be shrunk by repo settings.json");
       assert.equal(cfg.server.replyTimeoutSec, DEFAULTS().server.replyTimeoutSec, "reply window must not be stretched by repo settings.json");
       assert.equal(cfg.server.asyncTimeoutSec, DEFAULTS().server.asyncTimeoutSec, "detached supervision window must not be stretched by repo settings.json");

--- a/pi-a2a/extensions/test/config.test.ts
+++ b/pi-a2a/extensions/test/config.test.ts
@@ -1,5 +1,5 @@
 import { assert } from "chai";
-import { buildA2ASettingsPatch, loadConfig, resolvePeer, authHeaders, normUrl, setConfigOverrides, writeSettingsA2A, gatewayEntries, gatewayKeyFromUrl, cleanHostName } from "../lib/config";
+import { buildA2ASettingsPatch, loadConfig, resolvePeer, authHeaders, normUrl, setConfigOverrides, writeSettingsA2A, gatewayEntries, gatewayKeyFromUrl, cleanHostName, SECURITY_ENV_KEYS } from "../lib/config";
 import { DEFAULTS } from "./helpers";
 import { makeTempDir } from "./tmp";
 import * as path from "node:path";
@@ -92,6 +92,12 @@ describe("config", () => {
           "A2A_CHILD_TRANSCRIPT_RETENTION_DAYS=1",
           "A2A_DISCOVERY_MDNS=true",
           "A2A_ENRICH_CARD=true",
+          // Abuse-control parity with sanitizeRepoA2ASettings: the repo must
+          // not raise the concurrency ceiling or stretch either supervision
+          // window (asyncTimeoutSec 0 = unbounded).
+          "A2A_MAX_CONCURRENT=1000",
+          "A2A_REPLY_TIMEOUT=1000000",
+          "A2A_ASYNC_TIMEOUT=1000000",
           // Non-security key must still be honored from the cwd file.
           "A2A_PORT=7777",
         ].join("\n"),
@@ -108,8 +114,11 @@ describe("config", () => {
       assert.isTrue(cfg.verifySsl, "verifySsl must not be disabled by repo .env.local");
       assert.equal(cfg.server.rateLimitPerMin, DEFAULTS().server.rateLimitPerMin, "rate limit must not be neutered by repo .env.local");
       assert.equal(cfg.server.maxPingpongTurns, DEFAULTS().server.maxPingpongTurns, "anti-loop cap must not be raised by repo .env.local");
-      assert.isTrue(cfg.server.childTranscripts, "childTranscripts must not be disabled by repo .env.local");
+assert.isTrue(cfg.server.childTranscripts, "childTranscripts must not be disabled by repo .env.local");
       assert.equal(cfg.server.childTranscriptRetentionDays, DEFAULTS().server.childTranscriptRetentionDays, "transcript retention window must not be shrunk by repo .env.local");
+      assert.equal(cfg.server.maxConcurrent, DEFAULTS().server.maxConcurrent, "concurrency cap must not be raised by repo .env.local");
+      assert.equal(cfg.server.replyTimeoutSec, DEFAULTS().server.replyTimeoutSec, "reply window must not be stretched by repo .env.local");
+      assert.equal(cfg.server.asyncTimeoutSec, DEFAULTS().server.asyncTimeoutSec, "detached supervision window must not be stretched by repo .env.local");
       assert.isFalse(cfg.discovery.mdns.enabled, "mDNS must not be force-enabled by repo .env.local");
       assert.equal(cfg.server.port, 7777, "non-security keys still honored from cwd .env.local");
     });
@@ -158,6 +167,25 @@ describe("config", () => {
     });
   });
 
+  it("SECURITY_ENV_KEYS covers the abuse-control server keys (env/settings parity)", () => {
+    // The .env.local fixture tests above cover the walk end-to-end but need
+    // real .env.local READS — machines that sandbox those reads (some coding
+    // agents cannot open dot-env files) mask them. This pins the key-set
+    // directly: every abuse-control env key the maintainer review flagged
+    // (A2A_ASYNC_TIMEOUT, A2A_REPLY_TIMEOUT, A2A_MAX_CONCURRENT) must be
+    // stripped from repo-controlled .env.local files, matching what
+    // sanitizeRepoA2ASettings strips from repo-controlled settings.json.
+    for (const k of [
+      "A2A_MAX_PINGPONG_TURNS",
+      "A2A_RATE_LIMIT",
+      "A2A_MAX_CONCURRENT",
+      "A2A_REPLY_TIMEOUT",
+      "A2A_ASYNC_TIMEOUT",
+    ]) {
+      assert.isTrue(SECURITY_ENV_KEYS.has(k), `${k} must be stripped from repo .env.local files`);
+    }
+  });
+
   it("sanitizes security keys from a REPO-CONTROLLED .pi/settings.json (settings injection guard)", () => {
     withIsolatedPiDir((dir) => {
       const cwd = path.join(dir, "repo");
@@ -181,8 +209,9 @@ describe("config", () => {
               maxConcurrent: 1000,
               maxPingpongTurns: 20,
               replyTimeoutSec: 1000000,
-              childTranscripts: false,
+childTranscripts: false,
               childTranscriptRetentionDays: 1,
+              asyncTimeoutSec: 1000000,
               port: 6001, // non-security key — must survive
             },
             discovery: {
@@ -210,8 +239,10 @@ describe("config", () => {
       assert.equal(cfg.server.rateLimitPerMin, DEFAULTS().server.rateLimitPerMin, "rate limit must not be neutered by repo settings.json");
       assert.equal(cfg.server.maxConcurrent, DEFAULTS().server.maxConcurrent, "concurrency cap must not be raised by repo settings.json");
       assert.equal(cfg.server.maxPingpongTurns, DEFAULTS().server.maxPingpongTurns, "anti-loop cap must not be raised by repo settings.json");
-      assert.isTrue(cfg.server.childTranscripts, "childTranscripts must not be disabled by repo settings.json");
+assert.isTrue(cfg.server.childTranscripts, "childTranscripts must not be disabled by repo settings.json");
       assert.equal(cfg.server.childTranscriptRetentionDays, DEFAULTS().server.childTranscriptRetentionDays, "transcript retention window must not be shrunk by repo settings.json");
+      assert.equal(cfg.server.replyTimeoutSec, DEFAULTS().server.replyTimeoutSec, "reply window must not be stretched by repo settings.json");
+      assert.equal(cfg.server.asyncTimeoutSec, DEFAULTS().server.asyncTimeoutSec, "detached supervision window must not be stretched by repo settings.json");
       assert.isFalse(cfg.discovery.mdns.enabled, "mDNS must not be force-enabled by repo settings.json");
       assert.equal(cfg.discovery.enrichCard, DEFAULTS().discovery.enrichCard, "enrichCard must not be forced on by repo settings.json");
       // Repo-sourced peer: callable, but NEVER auto-attached the shared token.
@@ -243,14 +274,19 @@ describe("config", () => {
 
   it("still honors security-relevant A2A_* from process env", () => {
     withIsolatedPiDir((dir) => {
-      const keys = ["A2A_SERVER_ENABLED", "A2A_BEARER_TOKEN"] as const;
+      const keys = ["A2A_SERVER_ENABLED", "A2A_BEARER_TOKEN", "A2A_ASYNC_TIMEOUT"] as const;
       const saved = keys.map((k) => [k, process.env[k]] as const);
       process.env.A2A_SERVER_ENABLED = "true";
       process.env.A2A_BEARER_TOKEN = "envtok";
+      process.env.A2A_ASYNC_TIMEOUT = "7200";
       try {
         const cfg = loadConfig({ cwd: dir });
         assert.isTrue(cfg.server.enabled);
         assert.equal(cfg.server.sharedToken, "envtok");
+        // The SECURITY_ENV_KEYS guard strips A2A_ASYNC_TIMEOUT only from
+        // repo-controlled .env.local FILES — the operator's own process env
+        // is the trusted path and must keep working.
+        assert.equal(cfg.server.asyncTimeoutSec, 7200);
       } finally {
         for (const [k, v] of saved) {
           if (v === undefined) delete process.env[k];

--- a/pi-a2a/extensions/test/helpers.ts
+++ b/pi-a2a/extensions/test/helpers.ts
@@ -13,6 +13,7 @@ export function DEFAULTS(): A2AConfig {
       workspace: "",
       maxConcurrent: 3,
       replyTimeoutSec: 300,
+      asyncTimeoutSec: 86400,
       agentName: "",
       publicUrl: "",
       sharedToken: "",

--- a/pi-a2a/extensions/test/server.test.ts
+++ b/pi-a2a/extensions/test/server.test.ts
@@ -7,7 +7,7 @@ import { DEFAULTS } from "./helpers";
 import { makeTempDir } from "./tmp";
 import { A2AServer, type SessionRunner } from "../lib/server";
 import type { A2AConfig } from "../lib/config";
-import { STATE_CANCELED, STATE_COMPLETED, STATE_FAILED, STATE_INPUT_REQUIRED, STATE_REJECTED } from "../lib/protocol";
+import { STATE_CANCELED, STATE_COMPLETED, STATE_FAILED, STATE_INPUT_REQUIRED, STATE_REJECTED, STATE_WORKING } from "../lib/protocol";
 import { authenticate } from "../lib/security";
 import { metrics } from "../lib/client";
 import { list as listRegistry } from "../lib/registry";
@@ -82,6 +82,19 @@ async function jsonRpc(url: string, method: string, params: any, headers: Record
     body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
   });
   return resp.json();
+}
+
+/** Poll tasks/get until the task reaches a terminal state (bounded). */
+async function pollTask(url: string, taskId: string, timeoutMs = 5000): Promise<any> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const r = await jsonRpc(url, "tasks/get", { id: taskId });
+    if (r.error) throw new Error(`tasks/get error: ${JSON.stringify(r.error)}`);
+    const state = r.result?.status?.state;
+    if ([STATE_COMPLETED, STATE_FAILED, STATE_CANCELED, STATE_REJECTED].includes(state)) return r.result;
+    if (Date.now() > deadline) throw new Error(`poll timeout; still ${state}`);
+    await new Promise((res) => setTimeout(res, 50));
+  }
 }
 
 describe("server", () => {
@@ -1111,7 +1124,185 @@ describe("server", () => {
         const r = await jsonRpc(url, "SendMessage", {
           message: { role: "ROLE_USER", parts: [{ text: "slow" }] },
         });
-        assert.equal(sendTask(r).status.state, STATE_FAILED);
+assert.equal(sendTask(r).status.state, STATE_FAILED);
+        // Classification comes from the abort reason (the supervision ground
+        // truth), not the runner's own "timeout" rejection above.
+        assert.match(sendTask(r).status.message?.parts?.[0]?.text ?? "", /reply timeout/);
+      } finally {
+        await stop();
+      }
+    });
+  });
+
+  describe("non-blocking dispatch (SendMessageConfiguration.returnImmediately)", () => {
+    it("acks WORKING immediately and completes in the background (GetTask)", async () => {
+      const runner: SessionRunner = async () => {
+        await new Promise((res) => setTimeout(res, 300));
+        return { reply: "done eventually", inputRequired: false };
+      };
+      const { url, stop } = await startServer({ cfg: DEFAULTS(), runner });
+      try {
+        const t0 = Date.now();
+        const r = await jsonRpc(url, "SendMessage", {
+          message: { role: "ROLE_USER", parts: [{ text: "long job" }] },
+          configuration: { returnImmediately: true },
+        });
+        const ackMs = Date.now() - t0;
+        // The ack must NOT wait for the 300ms runner — that is the whole point
+        // of non-blocking dispatch (the caller envelope stops bounding the run).
+        assert.isBelow(ackMs, 200, `ack took ${ackMs}ms; runner should still be pending`);
+        assert.equal(r.result.status.state, STATE_WORKING);
+        assert.match(r.result.id, /^task-/);
+        const task = await pollTask(url, r.result.id);
+        assert.equal(task.status.state, STATE_COMPLETED);
+        assert.equal(task.artifacts?.[0]?.parts?.[0]?.text, "done eventually");
+      } finally {
+        await stop();
+      }
+    });
+
+    it("accepts the snake_case return_immediately spelling", async () => {
+      // Delayed runner: with an instant one the run settles before the HTTP
+      // layer serializes the ack, so the ack legitimately carries the terminal
+      // state (the client handles that — fast tasks just return their result).
+      // A pending runner makes the WORKING assertion meaningful: it only holds
+      // if the server truly returned before the run finished.
+      const runner: SessionRunner = async () => {
+        await new Promise((res) => setTimeout(res, 150));
+        return { reply: "snake ok", inputRequired: false };
+      };
+      const { url, stop } = await startServer({ cfg: DEFAULTS(), runner });
+      try {
+        const r = await jsonRpc(url, "SendMessage", {
+          message: { role: "ROLE_USER", parts: [{ text: "hi" }] },
+          configuration: { return_immediately: true },
+        });
+        assert.equal(r.result.status.state, STATE_WORKING);
+        const task = await pollTask(url, r.result.id);
+        assert.equal(task.status.state, STATE_COMPLETED);
+      } finally {
+        await stop();
+      }
+    });
+
+    it("a detached run is NOT bounded by the reply window", async () => {
+      // Same config that FAILS a blocking task after 1s (see the reply-timeout
+      // suite above): detached, with the async window disabled (0), the run
+      // must outlive the reply window and complete.
+      const cfg = DEFAULTS();
+      cfg.server.replyTimeoutSec = 1;
+      cfg.server.asyncTimeoutSec = 0;
+      const runner: SessionRunner = async () => {
+        await new Promise((res) => setTimeout(res, 1600));
+        return { reply: "survived the reply window", inputRequired: false };
+      };
+      const { url, stop } = await startServer({ cfg, runner });
+      try {
+        const r = await jsonRpc(url, "SendMessage", {
+          message: { role: "ROLE_USER", parts: [{ text: "outlive the window" }] },
+          configuration: { returnImmediately: true },
+        });
+        assert.equal(r.result.status.state, STATE_WORKING);
+        const task = await pollTask(url, r.result.id, 6000);
+        assert.equal(task.status.state, STATE_COMPLETED);
+        assert.equal(task.artifacts?.[0]?.parts?.[0]?.text, "survived the reply window");
+      } finally {
+        await stop();
+      }
+    });
+
+    it("server.asyncTimeoutSec bounds a detached run and classifies it FAILED", async () => {
+      const cfg = DEFAULTS();
+      cfg.server.asyncTimeoutSec = 1;
+      // The runner rejects with its OWN error on abort (like a session runner
+      // whose prompt rejects with an SDK error) — the server must still
+      // classify by the abort REASON, which carries the descriptive window
+      // message. If it used the runner's error, a dispatcher could not tell a
+      // supervision kill from a worker crash.
+      const runner: SessionRunner = ({ signal }) =>
+        new Promise((_resolve, reject) => {
+          signal.addEventListener("abort", () => reject(new Error("async window hit")));
+        });
+      const { url, stop } = await startServer({ cfg, runner });
+      try {
+        const r = await jsonRpc(url, "SendMessage", {
+          message: { role: "ROLE_USER", parts: [{ text: "hang" }] },
+          configuration: { returnImmediately: true },
+        });
+        assert.equal(r.result.status.state, STATE_WORKING);
+        const task = await pollTask(url, r.result.id, 4000);
+        assert.equal(task.status.state, STATE_FAILED);
+        assert.match(task.status.message?.parts?.[0]?.text ?? "", /async timeout.*detached-task window/);
+      } finally {
+        await stop();
+      }
+    });
+
+    it("tasks/cancel cancels a detached run", async () => {
+      const runner: SessionRunner = ({ signal }) =>
+        new Promise((_resolve, reject) => {
+          signal.addEventListener("abort", () => reject(new Error("canceled")));
+        });
+      const { url, stop } = await startServer({ cfg: DEFAULTS(), runner });
+      try {
+        const r = await jsonRpc(url, "SendMessage", {
+          message: { role: "ROLE_USER", parts: [{ text: "cancel me" }] },
+          configuration: { returnImmediately: true },
+        });
+        assert.equal(r.result.status.state, STATE_WORKING);
+        const c = await jsonRpc(url, "tasks/cancel", { id: r.result.id });
+        assert.equal(c.result.status.state, STATE_CANCELED);
+        const task = await pollTask(url, r.result.id);
+        assert.equal(task.status.state, STATE_CANCELED);
+      } finally {
+        await stop();
+      }
+    });
+
+    it("a detached runner failure is visible via GetTask as FAILED with the message", async () => {
+      const runner: SessionRunner = async () => {
+        throw new Error("worker exploded");
+      };
+      const { url, stop } = await startServer({ cfg: DEFAULTS(), runner });
+      try {
+        const r = await jsonRpc(url, "SendMessage", {
+          message: { role: "ROLE_USER", parts: [{ text: "will fail" }] },
+          configuration: { returnImmediately: true },
+        });
+        const task = await pollTask(url, r.result.id);
+        assert.equal(task.status.state, STATE_FAILED);
+        assert.match(task.status.message?.parts?.[0]?.text ?? "", /worker exploded/);
+      } finally {
+        await stop();
+      }
+    });
+
+    it("returnImmediately has no effect on message/stream (spec §3.2.2)", async () => {
+      const { url, stop } = await startServer({ cfg: DEFAULTS(), runner: stubRunner("streamed reply") });
+      try {
+        const resp = await fetch(url, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: "sse-async",
+            method: "message/stream",
+            params: {
+              message: { role: "ROLE_USER", parts: [{ text: "hi" }] },
+              configuration: { returnImmediately: true },
+            },
+          }),
+        });
+        const text = await resp.text();
+        const frames = text
+          .split("\n")
+          .filter((l) => l.startsWith("data:"))
+          .map((l) => JSON.parse(l.replace(/^data:\s*/, "")));
+        const statusFrame = frames.find((f) => f.result?.statusUpdate);
+        // Streaming keeps its blocking semantics: the final statusUpdate is the
+        // COMPLETED task, not an early WORKING ack.
+        assert.equal(statusFrame?.result?.statusUpdate?.status?.state, STATE_COMPLETED);
+>>>>>>> 98e5e04 (feat(pi-a2a): non-blocking dispatch (returnImmediately) + a2a_status polling (#340))
       } finally {
         await stop();
       }

--- a/pi-a2a/extensions/test/server.test.ts
+++ b/pi-a2a/extensions/test/server.test.ts
@@ -1151,9 +1151,9 @@ assert.equal(sendTask(r).status.state, STATE_FAILED);
         // The ack must NOT wait for the 300ms runner — that is the whole point
         // of non-blocking dispatch (the caller envelope stops bounding the run).
         assert.isBelow(ackMs, 200, `ack took ${ackMs}ms; runner should still be pending`);
-        assert.equal(r.result.status.state, STATE_WORKING);
-        assert.match(r.result.id, /^task-/);
-        const task = await pollTask(url, r.result.id);
+        assert.equal(sendTask(r).status.state, STATE_WORKING);
+        assert.match(sendTask(r).id, /^task-/);
+        const task = await pollTask(url, sendTask(r).id);
         assert.equal(task.status.state, STATE_COMPLETED);
         assert.equal(task.artifacts?.[0]?.parts?.[0]?.text, "done eventually");
       } finally {
@@ -1177,8 +1177,8 @@ assert.equal(sendTask(r).status.state, STATE_FAILED);
           message: { role: "ROLE_USER", parts: [{ text: "hi" }] },
           configuration: { return_immediately: true },
         });
-        assert.equal(r.result.status.state, STATE_WORKING);
-        const task = await pollTask(url, r.result.id);
+        assert.equal(sendTask(r).status.state, STATE_WORKING);
+        const task = await pollTask(url, sendTask(r).id);
         assert.equal(task.status.state, STATE_COMPLETED);
       } finally {
         await stop();
@@ -1202,8 +1202,8 @@ assert.equal(sendTask(r).status.state, STATE_FAILED);
           message: { role: "ROLE_USER", parts: [{ text: "outlive the window" }] },
           configuration: { returnImmediately: true },
         });
-        assert.equal(r.result.status.state, STATE_WORKING);
-        const task = await pollTask(url, r.result.id, 6000);
+        assert.equal(sendTask(r).status.state, STATE_WORKING);
+        const task = await pollTask(url, sendTask(r).id, 6000);
         assert.equal(task.status.state, STATE_COMPLETED);
         assert.equal(task.artifacts?.[0]?.parts?.[0]?.text, "survived the reply window");
       } finally {
@@ -1229,8 +1229,8 @@ assert.equal(sendTask(r).status.state, STATE_FAILED);
           message: { role: "ROLE_USER", parts: [{ text: "hang" }] },
           configuration: { returnImmediately: true },
         });
-        assert.equal(r.result.status.state, STATE_WORKING);
-        const task = await pollTask(url, r.result.id, 4000);
+        assert.equal(sendTask(r).status.state, STATE_WORKING);
+        const task = await pollTask(url, sendTask(r).id, 4000);
         assert.equal(task.status.state, STATE_FAILED);
         assert.match(task.status.message?.parts?.[0]?.text ?? "", /async timeout.*detached-task window/);
       } finally {
@@ -1249,10 +1249,10 @@ assert.equal(sendTask(r).status.state, STATE_FAILED);
           message: { role: "ROLE_USER", parts: [{ text: "cancel me" }] },
           configuration: { returnImmediately: true },
         });
-        assert.equal(r.result.status.state, STATE_WORKING);
-        const c = await jsonRpc(url, "tasks/cancel", { id: r.result.id });
+        assert.equal(sendTask(r).status.state, STATE_WORKING);
+        const c = await jsonRpc(url, "tasks/cancel", { id: sendTask(r).id });
         assert.equal(c.result.status.state, STATE_CANCELED);
-        const task = await pollTask(url, r.result.id);
+        const task = await pollTask(url, sendTask(r).id);
         assert.equal(task.status.state, STATE_CANCELED);
       } finally {
         await stop();
@@ -1269,7 +1269,7 @@ assert.equal(sendTask(r).status.state, STATE_FAILED);
           message: { role: "ROLE_USER", parts: [{ text: "will fail" }] },
           configuration: { returnImmediately: true },
         });
-        const task = await pollTask(url, r.result.id);
+        const task = await pollTask(url, sendTask(r).id);
         assert.equal(task.status.state, STATE_FAILED);
         assert.match(task.status.message?.parts?.[0]?.text ?? "", /worker exploded/);
       } finally {
@@ -1308,8 +1308,8 @@ assert.equal(sendTask(r).status.state, STATE_FAILED);
           message: { role: "ROLE_USER", parts: [{ text: "will fail" }] },
           configuration: { returnImmediately: true },
         });
-        assert.equal(r.result.status.state, STATE_WORKING);
-        const task = await pollTask(url, r.result.id);
+        assert.equal(sendTask(r).status.state, STATE_WORKING);
+        const task = await pollTask(url, sendTask(r).id);
         assert.equal(task.status.state, STATE_FAILED);
         assert.match(task.status.message?.parts?.[0]?.text ?? "", /worker exploded/);
         // The poll above let the event loop turn; any unhandled rejection
@@ -1337,8 +1337,8 @@ assert.equal(sendTask(r).status.state, STATE_FAILED);
         const r = await jsonRpc(url, "SendMessage", {
           message: { role: "ROLE_USER", parts: [{ text: "spoof attempt" }] },
         });
-        assert.equal(r.result.status.state, STATE_FAILED);
-        const msg = r.result.status.message?.parts?.[0]?.text ?? "";
+        assert.equal(sendTask(r).status.state, STATE_FAILED);
+        const msg = sendTask(r).status.message?.parts?.[0]?.text ?? "";
         assert.equal(msg, "reply timeout: this text lies");
         assert.notInclude(msg, "window");
       } finally {
@@ -1361,8 +1361,8 @@ assert.equal(sendTask(r).status.state, STATE_FAILED);
         const r = await jsonRpc(url, "SendMessage", {
           message: { role: "ROLE_USER", parts: [{ text: "slow but allowed" }] },
         });
-        assert.equal(r.result.status.state, STATE_COMPLETED);
-        assert.equal(r.result.artifacts?.[0]?.parts?.[0]?.text, "outlived a zero window");
+        assert.equal(sendTask(r).status.state, STATE_COMPLETED);
+        assert.equal(sendTask(r).artifacts?.[0]?.parts?.[0]?.text, "outlived a zero window");
       } finally {
         await stop();
       }

--- a/pi-a2a/extensions/test/server.test.ts
+++ b/pi-a2a/extensions/test/server.test.ts
@@ -1277,6 +1277,97 @@ assert.equal(sendTask(r).status.state, STATE_FAILED);
       }
     });
 
+    it("contains an unexpected throw on the detached path (no unhandled rejection; task FAILED)", async () => {
+      // A failing runner + an onActivity sink that throws on the "failed"
+      // event makes executeTask reject AFTER the ack already returned — the
+      // floating-promise path. The detached observer must contain it: the
+      // task still lands FAILED with the runner's message (set before the
+      // sink threw), and the process must not die of an unhandled rejection.
+      const runner: SessionRunner = async () => {
+        // Fail AFTER the ack is serialized, so the rejection genuinely lands
+        // on the detached path (an instantly-throwing runner can lose the
+        // race and mutate the task before the HTTP layer serializes the ack).
+        await new Promise((res) => setTimeout(res, 150));
+        throw new Error("worker exploded");
+      };
+      const onActivity = (a: any) => {
+        if (a.type === "failed") throw new Error("activity sink exploded");
+      };
+      const { url, stop } = await startServer({ cfg: DEFAULTS(), runner, onActivity });
+      // Observe process-level unhandled rejections for the duration of the
+      // scenario: the detached `execution` promise must never surface as one.
+      // (A bare test would not discriminate — mocha installs its own
+      // unhandledRejection handler that swallows detached rejections.)
+      let unhandled: unknown = null;
+      const onUnhandled = (e: unknown) => {
+        unhandled = e ?? new Error("unhandled rejection");
+      };
+      process.on("unhandledRejection", onUnhandled);
+      try {
+        const r = await jsonRpc(url, "SendMessage", {
+          message: { role: "ROLE_USER", parts: [{ text: "will fail" }] },
+          configuration: { returnImmediately: true },
+        });
+        assert.equal(r.result.status.state, STATE_WORKING);
+        const task = await pollTask(url, r.result.id);
+        assert.equal(task.status.state, STATE_FAILED);
+        assert.match(task.status.message?.parts?.[0]?.text ?? "", /worker exploded/);
+        // The poll above let the event loop turn; any unhandled rejection
+        // from the detached path has fired by now.
+        assert.isNull(unhandled, `detached path must not produce an unhandled rejection (got: ${String(unhandled)})`);
+      } finally {
+        process.off("unhandledRejection", onUnhandled);
+        await stop();
+      }
+    });
+
+    it("classification is keyed to the supervision timer, not the abort-reason text", async () => {
+      // No supervision timer fires here (replyTimeoutSec is large); the
+      // runner rejects with its own "reply timeout:"-prefixed error. The
+      // task must be FAILED with the runner's message PASSED THROUGH VERBATIM
+      // — supervision wording ("…window") may only ever come from OUR timer,
+      // so a lying runner cannot pose as a supervision kill.
+      const cfg = DEFAULTS();
+      cfg.server.replyTimeoutSec = 60;
+      const runner: SessionRunner = async () => {
+        throw new Error("reply timeout: this text lies");
+      };
+      const { url, stop } = await startServer({ cfg, runner });
+      try {
+        const r = await jsonRpc(url, "SendMessage", {
+          message: { role: "ROLE_USER", parts: [{ text: "spoof attempt" }] },
+        });
+        assert.equal(r.result.status.state, STATE_FAILED);
+        const msg = r.result.status.message?.parts?.[0]?.text ?? "";
+        assert.equal(msg, "reply timeout: this text lies");
+        assert.notInclude(msg, "window");
+      } finally {
+        await stop();
+      }
+    });
+
+    it("replyTimeoutSec 0 means NO reply-window timer (unbounded), not instant timeout", async () => {
+      // Pre-async-dispatch, replyTimeoutSec 0 armed setTimeout(…, 0) = an
+      // instant timeout. The >0 guard redefined 0 to "no timer"; this pins
+      // the documented reading (0 = unbounded, same as asyncTimeoutSec).
+      const cfg = DEFAULTS();
+      cfg.server.replyTimeoutSec = 0;
+      const runner: SessionRunner = async () => {
+        await new Promise((res) => setTimeout(res, 400));
+        return { reply: "outlived a zero window", inputRequired: false };
+      };
+      const { url, stop } = await startServer({ cfg, runner });
+      try {
+        const r = await jsonRpc(url, "SendMessage", {
+          message: { role: "ROLE_USER", parts: [{ text: "slow but allowed" }] },
+        });
+        assert.equal(r.result.status.state, STATE_COMPLETED);
+        assert.equal(r.result.artifacts?.[0]?.parts?.[0]?.text, "outlived a zero window");
+      } finally {
+        await stop();
+      }
+    });
+
     it("returnImmediately has no effect on message/stream (spec §3.2.2)", async () => {
       const { url, stop } = await startServer({ cfg: DEFAULTS(), runner: stubRunner("streamed reply") });
       try {
@@ -1302,7 +1393,6 @@ assert.equal(sendTask(r).status.state, STATE_FAILED);
         // Streaming keeps its blocking semantics: the final statusUpdate is the
         // COMPLETED task, not an early WORKING ack.
         assert.equal(statusFrame?.result?.statusUpdate?.status?.state, STATE_COMPLETED);
->>>>>>> 98e5e04 (feat(pi-a2a): non-blocking dispatch (returnImmediately) + a2a_status polling (#340))
       } finally {
         await stop();
       }


### PR DESCRIPTION
## Problem
A2A dispatch is synchronous-await only: message/send blocks until the remote task finishes, and there is no submit-and-poll path. Long-running fleet work (ops tasks, multi-host onboarding) gets killed by the caller reply window — sessions aborted mid-run, work done but closure lost. The timeouts.async config is parsed but never read (dead config).

## Fix
Spec-native non-blocking subset (A2A v1.0 section 3.2.2, camelCase per section 5.5):
- SendMessage with configuration.returnImmediately true → server acks the Task in TASK_STATE_WORKING immediately; the runner detaches from the HTTP envelope.
- New server.asyncTimeoutSec (default 86400s, 0 = unbounded) supervises detached runs; overflow → FAILED (per the fleet's established timeout semantics).
- Caller polls via GetTask (new a2a_status tool) or reads completion from the fleet queue. timeouts.async is now load-bearing as the poll interval.
- Rejected: full async lifecycle with push notifications (duplicates the queue), server-wide detached default (breaks sync knowledge queries), bigger caller timeouts (keeps the envelope-kill).

Also fixes a pre-existing leaked supervision timer (catch path never cleared it) that kept the test process alive after the suite.

## Tests
- 335 passing / 2 failing (both known-environmental sandbox config-read failures; fail identically on a clean stashed base).
- Non-blocking behavior deterministically proven via a 150ms delayed runner.
- asyncTimeoutSec FAILED-classification covered (abort reason message + reply-timeout assertion).
- Hermes-side companion: async_dispatch + a2a_status tools (4 new tests, 169 a2a tests green).
- Live-verified cross-host: returnImmediately ack 0.16-0.18s (TASK_STATE_WORKING, caller free), GetTask → COMPLETED, queue round-trip confirmed.

Fleet record: ca704776 (decision, runtime-verified).
