### PR TITLE
pi-a2a: return A2A v1.0 wire shapes on the v1.0 methods

### DIFF
--- a/pi-a2a/README.md
+++ b/pi-a2a/README.md
@@ -478,7 +478,14 @@ works out of the box:
 
 ## Protocol compliance
 
-Implements the A2A Protocol v1.0 JSON-RPC binding:
+Implements the A2A Protocol v1.0 JSON-RPC binding. v1.0 method names
+(`SendMessage`, `SendStreamingMessage`, `GetTask`, `ListTasks`, `CancelTask`,
+`SubscribeToTask`) speak the v1.0 wire shapes — `SendMessage` replies with the
+oneof `{"task": …}` / `{"message": …}` wrapper, streaming emits
+`TaskStatusUpdateEvent` / `TaskArtifactUpdateEvent` frames, and `ListTasks`
+returns full `Task` objects. The pre-1.0 path aliases (`message/send`,
+`message/stream`, `tasks/get`, …) keep the legacy wire shapes (bare `Task`
+results, `{id, state}` list stubs) so existing peers see no change.
 
 | Feature | Status |
 |---------|--------|

--- a/pi-a2a/extensions/lib/protocol.ts
+++ b/pi-a2a/extensions/lib/protocol.ts
@@ -282,11 +282,32 @@ export function unwrapSendMessageResponse(result: any): any {
   return result;
 }
 
+/** Wrap a Task as the v1.0 SendMessageResponse oneof {"task": …}. */
+export const sendTaskResponse = (task: any): any => ({ task });
+
 // StreamResponse builders (v1.0).
 export const streamTask = (task: any): any => ({ task });
 export const streamMessage = (message: any): any => ({ message });
-export const streamStatusUpdate = (task: any): any => ({ statusUpdate: task });
-export const streamArtifactUpdate = (artifact: any): any => ({ artifactUpdate: artifact });
+
+/** v1.0 TaskStatusUpdateEvent — {taskId, contextId, status, final}. */
+export const statusUpdateEvent = (task: any, final: boolean): any => ({
+  statusUpdate: {
+    taskId: task?.id,
+    contextId: task?.contextId,
+    status: task?.status,
+    final,
+  },
+});
+
+/** v1.0 TaskArtifactUpdateEvent — {taskId, contextId, artifact, lastChunk}. */
+export const artifactUpdateEvent = (task: any, artifact: any, lastChunk = true): any => ({
+  artifactUpdate: {
+    taskId: task?.id,
+    contextId: task?.contextId,
+    artifact,
+    lastChunk,
+  },
+});
 
 // ---------------------------------------------------------------------------
 // Parts (v1.0 member-presence discriminated; v0.3 `kind` tolerant)

--- a/pi-a2a/extensions/lib/server.ts
+++ b/pi-a2a/extensions/lib/server.ts
@@ -29,11 +29,15 @@ import {
   buildAgentCard,
   buildTask,
   extractText,
+  artifactUpdateEvent,
   jsonrpcError,
   jsonrpcResult,
   newContextId,
   newTaskId,
   normalizeRole,
+  sendTaskResponse,
+  statusUpdateEvent,
+  TERMINAL_STATES,
   uuid,
   type AgentCard,
   type AgentSkill,
@@ -808,6 +812,10 @@ export class A2AServer {
 
     // Normalize method aliases (v1.0 PascalCase ↔ pre-1.0 path).
     const norm = method.toLowerCase().replace(/[/_.-]/g, "");
+    // v1.0 methods ("SendMessage", "ListTasks", …) speak the v1.0 wire shapes;
+    // the pre-1.0 aliases ("message/send", "tasks/list", …) keep the legacy
+    // shapes old peers were built against.
+    const isV1 = (v1Norm: string): boolean => norm === v1Norm;
 
     if (norm === "messagesend" || norm === "sendmessage") {
       // Concurrency cap: reject when too many tasks are already running.
@@ -819,10 +827,12 @@ export class A2AServer {
         );
       }
       const r = await this.messageSend(params, identity);
-      return this.send(res, 200, jsonrpcResult(id, r));
+      // A2A v1.0: the SendMessage result is the oneof {"task": …} | {"message": …},
+      // never a bare Task; the pre-1.0 alias keeps returning the bare Task.
+      return this.send(res, 200, jsonrpcResult(id, isV1("sendmessage") ? sendTaskResponse(r) : r));
     }
     if (norm === "messagestream" || norm === "sendstreamingmessage") {
-      return this.messageStream(params, identity, res, id);
+      return this.messageStream(params, identity, res, id, isV1("sendstreamingmessage"));
     }
     if (norm === "tasksget" || norm === "gettask") {
       const st = this.store.get(String(params.id ?? ""));
@@ -833,8 +843,11 @@ export class A2AServer {
     }
     if (norm === "taskslist" || norm === "listtasks") {
       // Per-identity ownership (#10): only the caller's own tasks are listed.
-      const all = this.store.list().filter((t) => this.store.get(t.id)?.identity === identity).map((t) => ({ id: t.id, state: t.status.state }));
-      return this.send(res, 200, jsonrpcResult(id, { tasks: all }));
+      const mine = this.store.list().filter((t) => this.store.get(t.id)?.identity === identity);
+      // A2A v1.0: ListTasksResponse carries full Task objects; the pre-1.0
+      // alias keeps the {id, state} stubs it always returned.
+      const tasks = isV1("listtasks") ? mine : mine.map((t) => ({ id: t.id, state: t.status.state }));
+      return this.send(res, 200, jsonrpcResult(id, { tasks }));
     }
     if (norm === "taskscancel" || norm === "canceltask") {
       const st = this.store.get(String(params.id ?? ""));
@@ -854,7 +867,7 @@ export class A2AServer {
     }
     if (norm === "taskssubscribe" || norm === "subscribetotask") {
       // Resubscribe via SSE — same shape as message/stream.
-      return this.taskSubscribe(params, identity, res, id);
+      return this.taskSubscribe(params, identity, res, id, isV1("subscribetotask"));
     }
     return this.send(res, 200, jsonrpcError(id, -32601, `method not found: ${method}`));
   }
@@ -976,7 +989,7 @@ export class A2AServer {
     }
   }
 
-  private messageStream(params: any, identity: string, res: ServerResponse, id: any): void {
+  private messageStream(params: any, identity: string, res: ServerResponse, id: any, v1 = false): void {
     // Concurrency cap: same gate as message/send. Streaming has already sent
     // 200 + headers, so we emit a JSON-RPC error frame and close the stream.
     if (this.running >= this.cfg.server.maxConcurrent) {
@@ -1026,9 +1039,20 @@ export class A2AServer {
 
     this.messageSend(params, identity, disconnect.signal)
       .then((task) => {
-        writeSse({ statusUpdate: task });
-        if (task.artifacts) {
-          for (const a of task.artifacts) writeSse({ artifactUpdate: a });
+        if (v1) {
+          // A2A v1.0: TaskArtifactUpdateEvents deliver the content, then the
+          // terminal TaskStatusUpdateEvent closes the interaction — the last
+          // frame carries taskId/contextId/state, so a client reading only the
+          // final event still learns the identifiers.
+          for (const a of task.artifacts ?? []) writeSse(artifactUpdateEvent(task, a));
+          writeSse(statusUpdateEvent(task, true));
+        } else {
+          // Pre-1.0 alias keeps the legacy shapes (whole Task as statusUpdate,
+          // bare artifact as artifactUpdate).
+          writeSse({ statusUpdate: task });
+          if (task.artifacts) {
+            for (const a of task.artifacts) writeSse({ artifactUpdate: a });
+          }
         }
       })
       .catch((e: any) => writeErr(-32603, e?.message || String(e)))
@@ -1042,7 +1066,7 @@ export class A2AServer {
       });
   }
 
-  private taskSubscribe(params: any, identity: string, res: ServerResponse, id: any): void {
+  private taskSubscribe(params: any, identity: string, res: ServerResponse, id: any, v1 = false): void {
     const taskId = String(params.id ?? "");
     const st = this.store.get(taskId);
     // Ownership check (#10) BEFORE writing the SSE head, so a foreign peer gets
@@ -1079,12 +1103,16 @@ export class A2AServer {
       res.end();
       return;
     }
-    writeSse({ statusUpdate: st.task });
+    // v1.0: a TaskStatusUpdateEvent {taskId, contextId, status, final}; the
+    // pre-1.0 alias keeps the legacy whole-Task shape. A snapshot of an
+    // already-finished task is the final event of this stream.
+    writeSse(v1 ? statusUpdateEvent(st.task, st.done) : { statusUpdate: st.task });
     if (st.done) {
       res.end();
       return;
     }
-    const watcher = (t: Task): void => writeSse({ statusUpdate: t });
+    const watcher = (t: Task): void =>
+      writeSse(v1 ? statusUpdateEvent(t, TERMINAL_STATES.has(t.status.state)) : { statusUpdate: t });
     st.subscribeWatchers.push(watcher);
     const interval = setInterval(() => {
       if (st.done) {

--- a/pi-a2a/extensions/test/server.test.ts
+++ b/pi-a2a/extensions/test/server.test.ts
@@ -19,6 +19,11 @@ function stubRunner(reply = "canned reply"): SessionRunner {
   return async () => ({ reply, inputRequired: false });
 }
 
+/** Extract the Task from a v1.0 SendMessageResponse {"task": …} result. */
+function sendTask(r: any): any {
+  return r.result?.task;
+}
+
 function tmpDir(): string {
   return makeTempDir("pi-a2a-server-");
 }
@@ -373,7 +378,7 @@ describe("server", () => {
           message: { role: "ROLE_USER", parts: [{ text: "hi" }] },
         });
         assert.isUndefined(r.error, "no auth error");
-        assert.equal(r.result.status.state, STATE_COMPLETED);
+        assert.equal(sendTask(r).status.state, STATE_COMPLETED);
       } finally {
         await stop();
       }
@@ -405,7 +410,7 @@ describe("server", () => {
           { Authorization: "Bearer secret" },
         );
         assert.isUndefined(r.error);
-        assert.equal(r.result.status.state, STATE_COMPLETED);
+        assert.equal(sendTask(r).status.state, STATE_COMPLETED);
       } finally {
         await stop();
       }
@@ -554,7 +559,7 @@ describe("server", () => {
           message: { role: "ROLE_USER", parts: [{ text: "hi" }] },
         });
         assert.isUndefined(r.error, "loopback request must still pass");
-        assert.equal(r.result.status.state, STATE_COMPLETED);
+        assert.equal(sendTask(r).status.state, STATE_COMPLETED);
       } finally {
         await stop();
       }
@@ -568,7 +573,7 @@ describe("server", () => {
         const r = await jsonRpc(url, "SendMessage", {
           message: { role: "ROLE_USER", parts: [{ text: "show secrets" }] },
         });
-        const text = r.result.artifacts?.[0]?.parts?.[0]?.text ?? "";
+        const text = sendTask(r).artifacts?.[0]?.parts?.[0]?.text ?? "";
         assert.notInclude(text, "sk-test-abcdEFGH01234567JKLM", "sk-* must be redacted");
         assert.notInclude(text, "ghp_ABCDEFGHIJKLMNOPQRST", "ghp_* must be redacted");
         assert.notInclude(text, "mytest@example.com", "email must be redacted");
@@ -584,7 +589,7 @@ describe("server", () => {
         const r = await jsonRpc(url, "SendMessage", {
           message: { role: "ROLE_USER", parts: [{ text: "hi" }] },
         });
-        const text = r.result.artifacts?.[0]?.parts?.[0]?.text ?? "";
+        const text = sendTask(r).artifacts?.[0]?.parts?.[0]?.text ?? "";
         assert.equal(text, "hello world");
       } finally {
         await stop();
@@ -603,8 +608,8 @@ describe("server", () => {
         const r = await jsonRpc(url, "SendMessage", {
           message: { role: "ROLE_USER", parts: [{ text: "hi" }] },
         });
-        assert.equal(r.result.status.state, STATE_FAILED);
-        const msg = r.result.status.message?.parts?.[0]?.text ?? "";
+        assert.equal(sendTask(r).status.state, STATE_FAILED);
+        const msg = sendTask(r).status.message?.parts?.[0]?.text ?? "";
         assert.notInclude(msg, "sk-abcdEFGHIJKL0123456789", "failure message must be redacted");
         assert.include(msg, "[redacted]", "redaction placeholder present");
       } finally {
@@ -620,7 +625,7 @@ describe("server", () => {
         const r = await jsonRpc(url, "SendMessage", {
           message: { role: "ROLE_USER", parts: [{ text: "do something" }] },
         });
-        const task = r.result;
+        const task = sendTask(r);
         assert.equal(task.status.state, STATE_COMPLETED);
         assert.deepEqual(task.artifacts?.[0]?.parts?.[0], { text: "the real reply", mediaType: "text/plain" });
         assert.match(task.id, /^task-/);
@@ -637,7 +642,7 @@ describe("server", () => {
         const r = await jsonRpc(url, "SendMessage", {
           message: { role: "ROLE_USER", parts: [{ text: "hi" }] },
         });
-        assert.equal(r.result.status.state, STATE_INPUT_REQUIRED);
+        assert.equal(sendTask(r).status.state, STATE_INPUT_REQUIRED);
       } finally {
         await stop();
       }
@@ -661,7 +666,7 @@ describe("server", () => {
         const send = await jsonRpc(url, "SendMessage", {
           message: { role: "ROLE_USER", parts: [{ text: "hi" }] },
         });
-        const tid = send.result.id;
+        const tid = sendTask(send).id;
         const got = await jsonRpc(url, "tasks/get", { id: tid });
         assert.equal(got.result.id, tid);
         const list = await jsonRpc(url, "tasks/list", {});
@@ -765,7 +770,7 @@ describe("server", () => {
         const r = await jsonRpc(url, "SendMessage", {
           message: { role: "ROLE_USER", parts: [{ text: "hi" }] },
         });
-        assert.equal(r.result.status.state, STATE_COMPLETED);
+        assert.equal(sendTask(r).status.state, STATE_COMPLETED);
       } finally {
         await stop();
       }
@@ -782,16 +787,16 @@ describe("server", () => {
         const r1 = await jsonRpc(url, "SendMessage", {
           message: { role: "ROLE_USER", parts: [{ text: "t1" }], contextId: "ctx-loop" },
         });
-        assert.equal(r1.result.status.state, STATE_COMPLETED);
+        assert.equal(sendTask(r1).status.state, STATE_COMPLETED);
         const r2 = await jsonRpc(url, "SendMessage", {
           message: { role: "ROLE_USER", parts: [{ text: "t2" }], contextId: "ctx-loop" },
         });
-        assert.equal(r2.result.status.state, STATE_COMPLETED);
+        assert.equal(sendTask(r2).status.state, STATE_COMPLETED);
         // Third — rejected.
         const r3 = await jsonRpc(url, "SendMessage", {
           message: { role: "ROLE_USER", parts: [{ text: "t3" }], contextId: "ctx-loop" },
         });
-        assert.equal(r3.result.status.state, STATE_REJECTED);
+        assert.equal(sendTask(r3).status.state, STATE_REJECTED);
       } finally {
         await stop();
       }
@@ -820,7 +825,7 @@ describe("server", () => {
         assert.equal(cancel.result.status.state, STATE_CANCELED);
         // The original send resolves to a CANCELED task too.
         const send = await sendP;
-        assert.equal(send.result.status.state, STATE_CANCELED);
+        assert.equal(sendTask(send).status.state, STATE_CANCELED);
       } finally {
         await stop();
       }
@@ -832,7 +837,7 @@ describe("server", () => {
         const send = await jsonRpc(url, "SendMessage", {
           message: { role: "ROLE_USER", parts: [{ text: "hi" }] },
         });
-        const tid = send.result.id;
+        const tid = sendTask(send).id;
         const cancel = await jsonRpc(url, "tasks/cancel", { id: tid });
         assert.equal(cancel.error?.code, -32002);
       } finally {
@@ -850,7 +855,7 @@ describe("server", () => {
         const send = await jsonRpc(url, "SendMessage", {
           message: { role: "ROLE_USER", parts: [{ text: "alice task" }] },
         }, aliceH);
-        const tid = send.result.id;
+        const tid = sendTask(send).id;
         // Bob cannot fetch Alice's task or see it in his list.
         const foreignGet = await jsonRpc(url, "tasks/get", { id: tid }, bobH);
         assert.equal(foreignGet.error?.code, -32001, "foreign tasks/get must fail");
@@ -976,6 +981,120 @@ describe("server", () => {
     });
   });
 
+  describe("v1.0 wire shapes (PascalCase methods)", () => {
+    /** POST one JSON-RPC frame and return the parsed SSE data frames. */
+    async function sseFrames(url: string, method: string, params: any, id = "sse-v1"): Promise<any[]> {
+      const resp = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id, method, params }),
+      });
+      const text = await resp.text();
+      return text
+        .split("\n")
+        .filter((l) => l.startsWith("data:"))
+        .map((l) => JSON.parse(l.replace(/^data:\s*/, "")));
+    }
+
+    it("SendMessage returns the oneof {\"task\": …} wrapper, not a bare Task", async () => {
+      const { url, stop } = await startServer({ cfg: DEFAULTS(), runner: stubRunner("wrapped reply") });
+      try {
+        const r = await jsonRpc(url, "SendMessage", {
+          message: { role: "ROLE_USER", parts: [{ text: "hi" }] },
+        });
+        assert.isUndefined(r.error);
+        // The result must be the oneof wrapper with exactly the task member.
+        assert.exists(r.result?.task, "result must carry {task: …}");
+        assert.notExists(r.result?.message);
+        assert.equal(r.result.task.status.state, STATE_COMPLETED);
+        assert.equal(r.result.task.artifacts?.[0]?.parts?.[0]?.text, "wrapped reply");
+        // …and must not leak Task fields at the top level.
+        assert.isUndefined(r.result.status, "bare Task shape must not bleed through");
+      } finally {
+        await stop();
+      }
+    });
+
+    it("SendStreamingMessage emits TaskArtifactUpdateEvent then a final TaskStatusUpdateEvent", async () => {
+      const { url, stop } = await startServer({ cfg: DEFAULTS(), runner: stubRunner("stream body") });
+      try {
+        const frames = await sseFrames(url, "SendStreamingMessage", {
+          message: { role: "ROLE_USER", parts: [{ text: "hi" }] },
+        });
+        assert.isAtLeast(frames.length, 2, "artifact + terminal status events");
+        const artifacts = frames.filter((f) => f.result?.artifactUpdate);
+        const statuses = frames.filter((f) => f.result?.statusUpdate);
+        assert.equal(artifacts.length, 1, "one artifact event");
+        assert.equal(statuses.length, 1, "one terminal status event");
+        // TaskArtifactUpdateEvent: {taskId, contextId, artifact, lastChunk}.
+        const ae = artifacts[0]!.result.artifactUpdate;
+        assert.equal(ae.taskId, statuses[0]!.result.statusUpdate.taskId);
+        assert.equal(ae.contextId, statuses[0]!.result.statusUpdate.contextId);
+        assert.match(ae.taskId, /^task-/);
+        assert.match(ae.contextId, /^ctx-/);
+        assert.equal(ae.artifact?.parts?.[0]?.text, "stream body");
+        assert.equal(ae.lastChunk, true);
+        // TaskStatusUpdateEvent: {taskId, contextId, status, final}.
+        const se = statuses[0]!.result.statusUpdate;
+        assert.equal(se.status?.state, STATE_COMPLETED);
+        assert.equal(se.final, true);
+        // The artifact event precedes the terminal status event (the final
+        // frame carries the terminal state).
+        assert.isBelow(frames.indexOf(artifacts[0]!), frames.indexOf(statuses[0]!));
+        // No event may wrap a whole Task (the pre-1.0 shape).
+        for (const f of frames) {
+          assert.notExists(f.result?.task, "stream events must not be whole Tasks");
+          assert.notExists(f.result?.statusUpdate?.artifacts, "statusUpdate must be an event, not a Task");
+        }
+      } finally {
+        await stop();
+      }
+    });
+
+    it("ListTasks returns full Task objects; tasks/list keeps {id,state} stubs", async () => {
+      const { url, stop } = await startServer({ cfg: DEFAULTS(), runner: stubRunner("listed") });
+      try {
+        const send = await jsonRpc(url, "SendMessage", {
+          message: { role: "ROLE_USER", parts: [{ text: "hi" }] },
+        });
+        const tid = sendTask(send).id;
+        const v1 = await jsonRpc(url, "ListTasks", {});
+        assert.isAtLeast(v1.result?.tasks?.length, 1);
+        const mine = v1.result.tasks.find((t: any) => t.id === tid);
+        assert.exists(mine, "the created task is listed");
+        assert.equal(mine.status.state, STATE_COMPLETED);
+        assert.exists(mine.contextId, "full Task object, not an {id,state} stub");
+        const legacy = await jsonRpc(url, "tasks/list", {});
+        const stub = legacy.result.tasks.find((t: any) => t.id === tid);
+        assert.exists(stub);
+        assert.deepEqual(Object.keys(stub).sort(), ["id", "state"], "legacy alias keeps the stub shape");
+      } finally {
+        await stop();
+      }
+    });
+
+    it("SubscribeToTask emits a v1.0 TaskStatusUpdateEvent snapshot", async () => {
+      const { url, stop } = await startServer({ cfg: DEFAULTS(), runner: stubRunner("subscribed") });
+      try {
+        const send = await jsonRpc(url, "SendMessage", {
+          message: { role: "ROLE_USER", parts: [{ text: "hi" }] },
+        });
+        const tid = sendTask(send).id;
+        const frames = await sseFrames(url, "SubscribeToTask", { id: tid }, "sub-v1");
+        assert.isAtLeast(frames.length, 1);
+        const se = frames[0]!.result?.statusUpdate;
+        assert.exists(se, "snapshot statusUpdate event");
+        assert.equal(se.taskId, tid);
+        assert.match(se.contextId, /^ctx-/);
+        assert.equal(se.status?.state, STATE_COMPLETED);
+        assert.equal(se.final, true, "snapshot of a finished task is the final event");
+        assert.notExists(se.artifacts, "statusUpdate must be an event, not a Task");
+      } finally {
+        await stop();
+      }
+    });
+  });
+
   describe("reply timeout classifies as FAILED (not CANCELED)", () => {
     it("times out a slow task to STATE_FAILED", async () => {
       const cfg = DEFAULTS();
@@ -990,7 +1109,7 @@ describe("server", () => {
         const r = await jsonRpc(url, "SendMessage", {
           message: { role: "ROLE_USER", parts: [{ text: "slow" }] },
         });
-        assert.equal(r.result.status.state, STATE_FAILED);
+        assert.equal(sendTask(r).status.state, STATE_FAILED);
       } finally {
         await stop();
       }
@@ -1020,10 +1139,10 @@ describe("server", () => {
         const r = await jsonRpc(url, "SendMessage", {
           message: { role: "ROLE_USER", parts: [{ text: "long task" }] },
         });
-        assert.equal(r.result.status.state, STATE_FAILED);
-        const msgText = r.result.status.message?.parts?.[0]?.text ?? "";
+        assert.equal(sendTask(r).status.state, STATE_FAILED);
+        const msgText = sendTask(r).status.message?.parts?.[0]?.text ?? "";
         assert.include(msgText, "no usable reply", "status message explains the stunted turn");
-        assert.isUndefined(r.result.artifacts, "a stunted turn carries no reply artifact");
+        assert.isUndefined(sendTask(r).artifacts, "a stunted turn carries no reply artifact");
         // The host toast must say failed — not "completed (Ns)".
         assert.deepEqual(events.map((e) => e.type), ["arrived", "failed"]);
       } finally {
@@ -1039,7 +1158,7 @@ describe("server", () => {
         const r = await jsonRpc(url, "SendMessage", {
           message: { role: "ROLE_USER", parts: [{ text: "long task" }] },
         });
-        assert.equal(r.result.status.state, STATE_FAILED);
+        assert.equal(sendTask(r).status.state, STATE_FAILED);
         assert.equal(metrics.tasksCompleted, before, "stunted turns never increment completions");
         assert.equal(metrics.tasksFailed, beforeFailed + 1, "stunted turns increment failures");
       } finally {


### PR DESCRIPTION
# PR: pi-a2a: return A2A v1.0 wire shapes on the v1.0 methods

## Problem

The v1.0 JSON-RPC binding was advertised, but the four PascalCase methods
returned pre-1.0 wire shapes, so spec-built clients reject every reply:

1. **`SendMessage` returned the bare `Task`** where v1.0 defines
   `SendMessageResponse` as the oneof `{"task": …} | {"message": …}`. The
   reference client (a2a-go v2) fails every blocking and `returnImmediately`
   call with `"result violates A2A spec - unknown event type: [id contextId
   status artifacts]"` — lenient clients mask this, so two peers built
   against the same spec silently disagree.
2. **`SendStreamingMessage` / `SubscribeToTask` emitted `{statusUpdate: <whole
   Task>}` and `{artifactUpdate: <bare artifact>}`** where v1.0 defines
   `TaskStatusUpdateEvent {taskId, contextId, status, final}` and
   `TaskArtifactUpdateEvent {taskId, contextId, artifact, lastChunk}`. A
   spec-built client decodes `taskId: ""`, `artifact: null`.
3. **`ListTasks` returned `{id, state}` stubs** where v1.0
   `ListTasksResponse` carries full `Task` objects (clients render
   `TASK_STATE_UNSPECIFIED` and an empty `contextId` for every row).

## Fix

The method dispatcher already normalizes v1.0 PascalCase and pre-1.0 path
aliases to the same handler; this PR splits the *wire shape* the same way
(the same compatibility pattern hermes's A2A platform uses):

- v1.0 method names (`SendMessage`, `SendStreamingMessage`, `ListTasks`,
  `SubscribeToTask`) → v1.0 shapes:
  - `SendMessage` result wrapped as `{"task": Task}` (`sendTaskResponse`);
  - streams emit `TaskArtifactUpdateEvent`s carrying the artifacts, then one
    terminal `TaskStatusUpdateEvent` with `final: true` (the last frame
    carries `taskId`/`contextId`/state, so a client that reads only the
    final event still learns the identifiers — per the JSON-RPC/SSE binding,
    stream closure, not a `final` flag on every frame, is the termination
    signal);
  - `ListTasks` returns the full Task objects.
- pre-1.0 aliases (`message/send`, `message/stream`, `tasks/list`,
  `tasks/subscribe`) → keep the legacy shapes byte-for-byte, so existing
  peers see no change.
- `GetTask` / `CancelTask` were already conformant (bare `Task`), unchanged.
- Replaces the unused (and shape-wrong) `streamStatusUpdate` /
  `streamArtifactUpdate` builders in protocol.ts with correct
  `statusUpdateEvent` / `artifactUpdateEvent` builders.

## Tests

- 4 new tests in `server.test.ts` ("v1.0 wire shapes"): SendMessage wrapper
  oneof; SendStreamingMessage artifact-then-terminal-status event pair with
  full envelope fields; ListTasks full Task objects (and legacy stub shape
  preserved); SubscribeToTask v1.0 snapshot event.
- Updated existing tests to read `result.task` via a `sendTask` helper;
  legacy-alias tests unchanged and still passing.
- tsc strict clean; mocha 335 passing / 2 failing — both failures are the
  known environmental `.env.local` config tests (fail identically on
  pristine main).

## Verification beyond the suite

Verified with the official a2a-cli (a2a-go v2.5.0) as a neutral oracle
against a live host running this code: `a2a send` (blocking), `--async`
(returnImmediately ack + `task get` on the acked task), `--stream`
(artifact + terminal status events), `task get`, `task list` — all exit 0
post-fix, where blocking/async/stream all failed pre-fix.
